### PR TITLE
Slot number for secure edge hostnames

### DIFF
--- a/command_create_property.go
+++ b/command_create_property.go
@@ -28,7 +28,7 @@ import (
 	"encoding/json"
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/papi-v1"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/edgehostnames-v1"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/hapi-v1"
 	akamai "github.com/akamai/cli-common-golang"
 	"github.com/fatih/color"
 	"github.com/urfave/cli"
@@ -88,7 +88,7 @@ func cmdCreateProperty(c *cli.Context) error {
 	}
 
 	papi.Init(config)
-	edgehostnames.Init(config)
+	hapi.Init(config)
 
 	var tfData TFData
 	tfData.EdgeHostnames = make(map[string]EdgeHostname)
@@ -224,7 +224,7 @@ func cmdCreateProperty(c *cli.Context) error {
 		// Get slot details
 		ehnid := strings.Replace(hostname.EdgeHostnameID, "ehn_", "", 1)
 		
-		edgehostname, err := edgehostnames.GetEdgeHostnameById(ehnid)
+		edgehostname, err := hapi.GetEdgeHostnameById(ehnid)
 		if err != nil {
 			akamai.StopSpinnerFail()
 			return cli.NewExitError(color.RedString("Edge Hostname not found: %s", err), 1)


### PR DESCRIPTION
Update to use HAPI to get slot number for secure edge hostnames. Also update to use new PAPI method signatures (because someone changed Edgegrid-Golang)

NOTE: This requires that the pull request for Edgegrid-Golang (for HAPI) is merged first.