### PR TITLE
Change the URL to the binary (Closes #6)

### DIFF
--- a/cli.json
+++ b/cli.json
@@ -7,7 +7,7 @@
       "name": "terraform",
       "version": "0.2.0",
       "description": "Administer and Manage Akamai Terraform configurations",
-      "bin": "https://github.com/akamai/cli-terraform/releases/download/{{.Version}}/akamai-{{.Name}}-{{.Version}}-{{.OS}}{{.Arch}}{{.BinSuffix}}",
+      "bin": "https://github.com/akamai/cli-terraform/releases/download/v{{.Version}}/akamai-{{.Name}}-{{.Version}}-{{.OS}}{{.Arch}}{{.BinSuffix}}",
       "auto-complete": true
     }
   ]


### PR DESCRIPTION
I changed the cli.json file, and I was able to run the following command successfully:
```
$ akamai install https://github.com/DidierFort/cli-terraform.git
Attempting to fetch command from https://github.com/DidierFort/cli-terraform.git... ... [OK]
Installing... ... [WARN]
higher version is required to install this command: required: go:1.12.0, have: 1.10.4. Please upgrade your runtime
? Binary command(s) found, would you like to download and install it? Yes
Downloading binary... ... [OK]

Installed Commands:

  adaptive-acceleration (alias: a2)
    Reset A2 Push and Preconnect policy
...
  site-shield (alias: ss)
    Access details of Site-Shield Maps, CIDRs and acknowledgement
  terraform
    Administer and Manage Akamai Terraform configurations
  uninstall
    Uninstall package containing <command>
  update
    Update one or more commands. If no command is specified, all commands are updated
  upgrade
    Upgrade Akamai CLI to the latest version
  visitor-prioritization (alias: vp)
    Access and control Visitor Prioritization cloudlet

See "akamai help [command]" for details.
```

The latest version of cli-terraform is now installed:
```
$ akamai terraform --version
akamai terraform version 0.2.0
```

Regards,
Didier