### PR TITLE
Release/v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Version X.X.X (X X, 2023)
+
+### Features/Enhancements
+
+* Migrate to Terraform 1.3.7 version
+
 ## Version 1.5.0 (Apr 27, 2023)
 
 ### Features/Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Version X.X.X (X X, 2023)
 
+### Bug fixes
+* Fix escaping of `akamai_gtm_property` `static_rr_set.rdata` field
+
 ### Features/Enhancements
 
 * Migrate to Terraform 1.3.7 version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 # Release Notes
 
-## Version X.X.X (X X, 2023)
+## Version 1.6.0 (May 31, 2023)
 
 ### Bug fixes
 * Fix escaping of `akamai_gtm_property` `static_rr_set.rdata` field
+* Export of some fields depends on the fact if the rule is default or not
 
 ### Features/Enhancements
 
 * Migrate to Terraform 1.3.7 version
+* Flag `schema` works now with `include` sub-command as well with `with-includes` flag
 
 ## Version 1.5.0 (Apr 27, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 1.6.0 (May 31, 2023)
 
 ### Bug fixes
+
 * Fix escaping of `akamai_gtm_property` `static_rr_set.rdata` field
 * Export of some fields depends on the fact if the rule is default or not
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,35 @@ Flags:
 
 ## Property Manager Properties
 
+Certain export conditions require the use of a particular property rule format. Verify your rule format matches the use case requirement and [update your rule format](https://techdocs.akamai.com/terraform/docs/set-up-includes#update-rule-format) as needed.
+
+<table>
+<thead>
+  <tr>
+    <th>Export condition</th>
+    <th>Output</th>
+    <th>Rule format</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td>General</td>
+    <td>Your declarative property configuration and its JSON-formatted rules.</td>
+    <td>Any supported format.</td>
+  </tr>
+  <tr>
+    <td>Addition of <code>--schema</code> flag</td>
+    <td>Your declarative property configuration and HCL-formatted rules. <strong>Does not return includes</strong> as includes are JSON-formatted.</td>
+    <td>≥ <code>v2023_01_05</code></td>
+  </tr>
+  <tr>
+    <td>Addition of <code>include</code> subcommand</td>
+    <td>Your property configuration and its JSON-formatted rules and includes.</td>
+    <td>Any supported format, <em>but</em> your rules and includes must use the same rule format version.</td>
+  </tr>
+</tbody>
+</table>
+
 ### Usage
 
 ```
@@ -169,7 +198,7 @@ Flags:
    --tfworkpath path      Directory used to store files created when running commands. (default: current directory)
    --version value        Property version to import  (default: LATEST)
    --with-includes        Referenced includes will also be exported along with property
-   --schema               Referenced rules will be exported as `akamai_property_rules_builder` data source
+   --schema               Rules will be exported as `akamai_property_rules_builder` data source in HCL format.
 ```
 
 ### Export property manager property configuration.

--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ Flags:
    --schema               Rules will be exported as `akamai_property_rules_builder` data source in HCL format.
 ```
 
+> Flag `schema` works now with `include` sub-command as well with `with-includes` flag.
+
 ### Export property manager property configuration.
 
 ```

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,7 +11,7 @@ ENV PROVIDER_VERSION="1.0.0" \
 ARG SSH_PRV_KEY
 ARG SSH_PUB_KEY
 ARG SSH_KNOWN_HOSTS
-ARG TERRAFORM_VERSION="1.2.5"
+ARG TERRAFORM_VERSION="1.3.7"
 WORKDIR $GOPATH/src/github.com/akamai
 
 RUN apk add --update git bash sudo openssh gcc musl-dev openssl-dev ca-certificates unzip curl make && \

--- a/build/docker_jenkins.bash
+++ b/build/docker_jenkins.bash
@@ -95,7 +95,7 @@ docker exec akatf-container sh -c 'cd edgegrid; git checkout ${EDGEGRID_BRANCH_N
                                    cd ../cli; git checkout ${CLI_BRANCH_NAME};
                                    go mod tidy;
                                    cd ../cli-terraform; git checkout ${CLI_TERRAFORM_BRANCH_NAME};
-                                   go mod edit -replace github.com/akamai/AkamaiOPEN-edgegrid-golang/v5=../edgegrid;
+                                   go mod edit -replace github.com/akamai/AkamaiOPEN-edgegrid-golang/v6=../edgegrid;
                                    go mod edit -replace github.com/akamai/cli=../cli;
                                    go mod tidy'
 

--- a/build/docker_jenkins.bash
+++ b/build/docker_jenkins.bash
@@ -29,7 +29,7 @@ COVERAGE_HTML="$COVERAGE_DIR"/index.html
 
 WORKDIR="${WORKDIR-$(pwd)}"
 echo "WORKDIR is $WORKDIR"
-TERRAFORM_VERSION="1.2.5"
+TERRAFORM_VERSION="1.3.7"
 
 STASH_SERVER=git.source.akamai.com
 GIT_IP=$(dig +short $STASH_SERVER)

--- a/cli.json
+++ b/cli.json
@@ -5,7 +5,7 @@
   "commands": [
     {
       "name": "terraform",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "description": "Administer and Manage Akamai Terraform configurations",
       "bin": "https://github.com/akamai/cli-terraform/releases/download/v{{.Version}}/akamai-{{.Name}}-{{.Version}}-{{.OS}}{{.Arch}}{{.BinSuffix}}",
       "auto-complete": true,

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/session"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/session"
 	"github.com/akamai/cli-terraform/pkg/commands"
 	"github.com/akamai/cli-terraform/pkg/edgegrid"
 	akacli "github.com/akamai/cli/pkg/app"

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -33,7 +33,7 @@ import (
 
 var (
 	// Version holds current version of cli-terraform
-	Version = "1.5.0"
+	Version = "1.6.0"
 )
 
 // Run initializes the cli and runs it

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/session"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/session"
 	"github.com/akamai/cli/pkg/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli/v2"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/akamai/cli-terraform
 go 1.18
 
 require (
-	github.com/akamai/AkamaiOPEN-edgegrid-golang/v5 v5.0.0
+	github.com/akamai/AkamaiOPEN-edgegrid-golang/v6 v6.0.0
 	github.com/akamai/cli v1.5.3
 	github.com/fatih/color v1.13.0
 	github.com/hashicorp/hcl/v2 v2.11.1
@@ -53,5 +53,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-//replace github.com/akamai/AkamaiOPEN-edgegrid-golang/v5 => ../akamaiopen-edgegrid-golang
+//replace github.com/akamai/AkamaiOPEN-edgegrid-golang/v6 => ../akamaiopen-edgegrid-golang
 //replace github.com/akamai/cli => ../cli

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDO
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/akamai/AkamaiOPEN-edgegrid-golang/v5 v5.0.0 h1:/NUI7xSyyV+lkexQ2gZmsw+Vgche5tpqchPRT2ywnN0=
-github.com/akamai/AkamaiOPEN-edgegrid-golang/v5 v5.0.0/go.mod h1:i7L7M3mZO+UryCzIsE2/HCqDTX7icCYKtRyvut/O6rU=
+github.com/akamai/AkamaiOPEN-edgegrid-golang/v6 v6.0.0 h1:YR4Uce34BxhBWxtIqxm86kZ/WWK7v1A8aHBWSnzD3KI=
+github.com/akamai/AkamaiOPEN-edgegrid-golang/v6 v6.0.0/go.mod h1:9YKAQNAuk/p5qpbk/2kg28GI23VKpnrCzHOmml3YZzM=
 github.com/akamai/cli v1.5.3 h1:Qemz9dRzAmnDDJJiyATqPuC0j0JziyK1nvmPxb7RbMk=
 github.com/akamai/cli v1.5.3/go.mod h1:o0lvqfN7dOir6rnXPmhp5d9aOIPHyJri1MzduZ8fItg=
 github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 h1:MzBOUgng9orim59UnfUTLRjMpd09C5uEVQ6RPGeCaVI=

--- a/pkg/edgegrid/config.go
+++ b/pkg/edgegrid/config.go
@@ -2,7 +2,7 @@
 package edgegrid
 
 import (
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/edgegrid"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/edgegrid"
 	"github.com/urfave/cli/v2"
 )
 

--- a/pkg/edgegrid/config_test.go
+++ b/pkg/edgegrid/config_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/edgegrid"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/edgegrid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"

--- a/pkg/edgegrid/session.go
+++ b/pkg/edgegrid/session.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/session"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/session"
 	"github.com/urfave/cli/v2"
 )
 

--- a/pkg/edgegrid/session_test.go
+++ b/pkg/edgegrid/session_test.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/session"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/session"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"

--- a/pkg/providers/appsec/create_appsec.go
+++ b/pkg/providers/appsec/create_appsec.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/appsec"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/botman"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/appsec"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/botman"
 	"github.com/akamai/cli-terraform/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli-terraform/pkg/tools"

--- a/pkg/providers/appsec/create_appsec_test.go
+++ b/pkg/providers/appsec/create_appsec_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/appsec"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/botman"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/appsec"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/botman"
 	"github.com/akamai/cli-terraform/pkg/templates"
 
 	"github.com/stretchr/testify/assert"

--- a/pkg/providers/appsec/testdata/ase-botman.json
+++ b/pkg/providers/appsec/testdata/ase-botman.json
@@ -3601,9 +3601,20 @@
     "malwarePolicies": [
         {
             "contentTypes": [
-                "application/xml",
-                "audio/x-wav",
-                "application/json"
+                {
+                    "name": "text/value"
+                },
+                {
+                    "name": "application/json",
+                    "encodedContentAttributes": [
+                        {
+                            "path": "image.imagePath",
+                            "encoding": [
+                                "base64"
+                            ]
+                        }
+                    ]
+                }
             ],
             "description": "Malware configuration details",
             "hostnames": [
@@ -3619,9 +3630,20 @@
         },
         {
             "contentTypes": [
-                "application/msword",
-                "application/x-mswrite",
-                "application/rtf"
+                {
+                    "name": "text/value"
+                },
+                {
+                    "name": "application/json",
+                    "encodedContentAttributes": [
+                        {
+                            "path": "image.imagePath",
+                            "encoding": [
+                                "base64"
+                            ]
+                        }
+                    ]
+                }
             ],
             "description": "Malware configuration details",
             "hostnames": [
@@ -3635,8 +3657,20 @@
         },
         {
             "contentTypes": [
-                "application/xml",
-                "application/json"
+                {
+                    "name": "text/value"
+                },
+                {
+                    "name": "application/json",
+                    "encodedContentAttributes": [
+                        {
+                            "path": "image.imagePath",
+                            "encoding": [
+                                "base64"
+                            ]
+                        }
+                    ]
+                }
             ],
             "description": "Malware configuration details",
             "hostnames": [

--- a/pkg/providers/appsec/testdata/ase-botman/modules/security/malware-policies.tf
+++ b/pkg/providers/appsec/testdata/ase-botman/modules/security/malware-policies.tf
@@ -3,9 +3,20 @@ resource "akamai_appsec_malware_policy" "fms_configuration_1" {
   malware_policy = jsonencode(
     {
       "contentTypes" : [
-        "application/xml",
-        "audio/x-wav",
-        "application/json"
+        {
+          "name" : "text/value"
+        },
+        {
+          "encodedContentAttributes" : [
+            {
+              "encoding" : [
+                "base64"
+              ],
+              "path" : "image.imagePath"
+            }
+          ],
+          "name" : "application/json"
+        }
       ],
       "description" : "Malware configuration details",
       "hostnames" : [
@@ -26,9 +37,20 @@ resource "akamai_appsec_malware_policy" "fms_configuration_2" {
   malware_policy = jsonencode(
     {
       "contentTypes" : [
-        "application/msword",
-        "application/x-mswrite",
-        "application/rtf"
+        {
+          "name" : "text/value"
+        },
+        {
+          "encodedContentAttributes" : [
+            {
+              "encoding" : [
+                "base64"
+              ],
+              "path" : "image.imagePath"
+            }
+          ],
+          "name" : "application/json"
+        }
       ],
       "description" : "Malware configuration details",
       "hostnames" : [
@@ -47,8 +69,20 @@ resource "akamai_appsec_malware_policy" "fms_configuration_3" {
   malware_policy = jsonencode(
     {
       "contentTypes" : [
-        "application/xml",
-        "application/json"
+        {
+          "name" : "text/value"
+        },
+        {
+          "encodedContentAttributes" : [
+            {
+              "encoding" : [
+                "base64"
+              ],
+              "path" : "image.imagePath"
+            }
+          ],
+          "name" : "application/json"
+        }
       ],
       "description" : "Malware configuration details",
       "hostnames" : [

--- a/pkg/providers/appsec/testdata/ase.json
+++ b/pkg/providers/appsec/testdata/ase.json
@@ -3471,9 +3471,20 @@
     "malwarePolicies": [
         {
             "contentTypes": [
-                "application/xml",
-                "audio/x-wav",
-                "application/json"
+                {
+                    "name": "text/value"
+                },
+                {
+                    "name": "application/json",
+                    "encodedContentAttributes": [
+                        {
+                            "path": "image.imagePath",
+                            "encoding": [
+                                "base64"
+                            ]
+                        }
+                    ]
+                }
             ],
             "description": "Malware configuration details",
             "hostnames": [
@@ -3489,9 +3500,20 @@
         },
         {
             "contentTypes": [
-                "application/msword",
-                "application/x-mswrite",
-                "application/rtf"
+                {
+                    "name": "text/value"
+                },
+                {
+                    "name": "application/json",
+                    "encodedContentAttributes": [
+                        {
+                            "path": "image.imagePath",
+                            "encoding": [
+                                "base64"
+                            ]
+                        }
+                    ]
+                }
             ],
             "description": "Malware configuration details",
             "hostnames": [
@@ -3505,8 +3527,20 @@
         },
         {
             "contentTypes": [
-                "application/xml",
-                "application/json"
+                {
+                    "name": "text/value"
+                },
+                {
+                    "name": "application/json",
+                    "encodedContentAttributes": [
+                        {
+                            "path": "image.imagePath",
+                            "encoding": [
+                                "base64"
+                            ]
+                        }
+                    ]
+                }
             ],
             "description": "Malware configuration details",
             "hostnames": [

--- a/pkg/providers/appsec/testdata/ase/modules/security/malware-policies.tf
+++ b/pkg/providers/appsec/testdata/ase/modules/security/malware-policies.tf
@@ -3,9 +3,20 @@ resource "akamai_appsec_malware_policy" "fms_configuration_1" {
   malware_policy = jsonencode(
     {
       "contentTypes" : [
-        "application/xml",
-        "audio/x-wav",
-        "application/json"
+        {
+          "name" : "text/value"
+        },
+        {
+          "encodedContentAttributes" : [
+            {
+              "encoding" : [
+                "base64"
+              ],
+              "path" : "image.imagePath"
+            }
+          ],
+          "name" : "application/json"
+        }
       ],
       "description" : "Malware configuration details",
       "hostnames" : [
@@ -26,9 +37,20 @@ resource "akamai_appsec_malware_policy" "fms_configuration_2" {
   malware_policy = jsonencode(
     {
       "contentTypes" : [
-        "application/msword",
-        "application/x-mswrite",
-        "application/rtf"
+        {
+          "name" : "text/value"
+        },
+        {
+          "encodedContentAttributes" : [
+            {
+              "encoding" : [
+                "base64"
+              ],
+              "path" : "image.imagePath"
+            }
+          ],
+          "name" : "application/json"
+        }
       ],
       "description" : "Malware configuration details",
       "hostnames" : [
@@ -47,8 +69,20 @@ resource "akamai_appsec_malware_policy" "fms_configuration_3" {
   malware_policy = jsonencode(
     {
       "contentTypes" : [
-        "application/xml",
-        "application/json"
+        {
+          "name" : "text/value"
+        },
+        {
+          "encodedContentAttributes" : [
+            {
+              "encoding" : [
+                "base64"
+              ],
+              "path" : "image.imagePath"
+            }
+          ],
+          "name" : "application/json"
+        }
       ],
       "description" : "Malware configuration details",
       "hostnames" : [

--- a/pkg/providers/appsec/testdata/tcwest.json
+++ b/pkg/providers/appsec/testdata/tcwest.json
@@ -11059,9 +11059,20 @@
     "malwarePolicies": [
         {
             "contentTypes": [
-                "application/xml",
-                "audio/x-wav",
-                "application/json"
+                {
+                    "name": "text/value"
+                },
+                {
+                    "name": "application/json",
+                    "encodedContentAttributes": [
+                        {
+                            "path": "image.imagePath",
+                            "encoding": [
+                                "base64"
+                            ]
+                        }
+                    ]
+                }
             ],
             "description": "Malware configuration details",
             "hostnames": [
@@ -11077,9 +11088,20 @@
         },
         {
             "contentTypes": [
-                "application/msword",
-                "application/x-mswrite",
-                "application/rtf"
+                {
+                    "name": "text/value"
+                },
+                {
+                    "name": "application/json",
+                    "encodedContentAttributes": [
+                        {
+                            "path": "image.imagePath",
+                            "encoding": [
+                                "base64"
+                            ]
+                        }
+                    ]
+                }
             ],
             "description": "Malware configuration details",
             "hostnames": [
@@ -11093,8 +11115,20 @@
         },
         {
             "contentTypes": [
-                "application/xml",
-                "application/json"
+                {
+                    "name": "text/value"
+                },
+                {
+                    "name": "application/json",
+                    "encodedContentAttributes": [
+                        {
+                            "path": "image.imagePath",
+                            "encoding": [
+                                "base64"
+                            ]
+                        }
+                    ]
+                }
             ],
             "description": "Malware configuration details",
             "hostnames": [

--- a/pkg/providers/appsec/testdata/tcwest/modules/security/malware-policies.tf
+++ b/pkg/providers/appsec/testdata/tcwest/modules/security/malware-policies.tf
@@ -3,9 +3,20 @@ resource "akamai_appsec_malware_policy" "fms_configuration_1" {
   malware_policy = jsonencode(
     {
       "contentTypes" : [
-        "application/xml",
-        "audio/x-wav",
-        "application/json"
+        {
+          "name" : "text/value"
+        },
+        {
+          "encodedContentAttributes" : [
+            {
+              "encoding" : [
+                "base64"
+              ],
+              "path" : "image.imagePath"
+            }
+          ],
+          "name" : "application/json"
+        }
       ],
       "description" : "Malware configuration details",
       "hostnames" : [
@@ -26,9 +37,20 @@ resource "akamai_appsec_malware_policy" "fms_configuration_2" {
   malware_policy = jsonencode(
     {
       "contentTypes" : [
-        "application/msword",
-        "application/x-mswrite",
-        "application/rtf"
+        {
+          "name" : "text/value"
+        },
+        {
+          "encodedContentAttributes" : [
+            {
+              "encoding" : [
+                "base64"
+              ],
+              "path" : "image.imagePath"
+            }
+          ],
+          "name" : "application/json"
+        }
       ],
       "description" : "Malware configuration details",
       "hostnames" : [
@@ -47,8 +69,20 @@ resource "akamai_appsec_malware_policy" "fms_configuration_3" {
   malware_policy = jsonencode(
     {
       "contentTypes" : [
-        "application/xml",
-        "application/json"
+        {
+          "name" : "text/value"
+        },
+        {
+          "encodedContentAttributes" : [
+            {
+              "encoding" : [
+                "base64"
+              ],
+              "path" : "image.imagePath"
+            }
+          ],
+          "name" : "application/json"
+        }
       ],
       "description" : "Malware configuration details",
       "hostnames" : [

--- a/pkg/providers/appsec/testdata/tcwest/modules/security/rate-policies.tf
+++ b/pkg/providers/appsec/testdata/tcwest/modules/security/rate-policies.tf
@@ -2,7 +2,6 @@ resource "akamai_appsec_rate_policy" "high_rate" {
   config_id = akamai_appsec_configuration.config.config_id
   rate_policy = jsonencode(
     {
-      "additionalMatchOptions" : null,
       "averageThreshold" : 100,
       "burstThreshold" : 500,
       "clientIdentifier" : "ip",
@@ -22,7 +21,6 @@ resource "akamai_appsec_rate_policy" "low_rate" {
   config_id = akamai_appsec_configuration.config.config_id
   rate_policy = jsonencode(
     {
-      "additionalMatchOptions" : null,
       "averageThreshold" : 75,
       "burstThreshold" : 250,
       "clientIdentifier" : "ip",
@@ -42,10 +40,8 @@ resource "akamai_appsec_rate_policy" "bot_rate" {
   config_id = akamai_appsec_configuration.config.config_id
   rate_policy = jsonencode(
     {
-      "additionalMatchOptions" : null,
       "averageThreshold" : 25,
       "burstThreshold" : 50,
-      "clientIdentifier" : "",
       "matchType" : "path",
       "name" : "Bot Rate",
       "path" : {

--- a/pkg/providers/cloudlets/create_policy.go
+++ b/pkg/providers/cloudlets/create_policy.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 	"text/template"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/cloudlets"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/cloudlets"
 	"github.com/akamai/cli-terraform/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli-terraform/pkg/tools"

--- a/pkg/providers/cloudlets/create_policy_test.go
+++ b/pkg/providers/cloudlets/create_policy_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/cloudlets"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/cloudlets"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli-terraform/pkg/tools"
 	"github.com/akamai/cli/pkg/terminal"

--- a/pkg/providers/cps/create_cps.go
+++ b/pkg/providers/cps/create_cps.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/cps"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/cps"
 	"github.com/akamai/cli-terraform/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli-terraform/pkg/tools"

--- a/pkg/providers/cps/create_cps_test.go
+++ b/pkg/providers/cps/create_cps_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/cps"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/tools"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/cps"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/tools"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli/pkg/terminal"
 	"github.com/stretchr/testify/assert"

--- a/pkg/providers/dns/command_create_zone.go
+++ b/pkg/providers/dns/command_create_zone.go
@@ -26,7 +26,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/dns"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/dns"
 	"github.com/akamai/cli-terraform/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/pkg/tools"
 	"github.com/akamai/cli/pkg/terminal"

--- a/pkg/providers/dns/template_processing.go
+++ b/pkg/providers/dns/template_processing.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/dns"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/dns"
 )
 
 //go:embed templates/*

--- a/pkg/providers/dns/tf_recordsets.go
+++ b/pkg/providers/dns/tf_recordsets.go
@@ -20,7 +20,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/dns"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/dns"
 	"github.com/shirou/gopsutil/mem"
 )
 

--- a/pkg/providers/dns/tf_recordsets_test.go
+++ b/pkg/providers/dns/tf_recordsets_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/dns"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/dns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/pkg/providers/dns/tf_zone.go
+++ b/pkg/providers/dns/tf_zone.go
@@ -17,7 +17,7 @@ package dns
 import (
 	"context"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/dns"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/dns"
 )
 
 // process zone

--- a/pkg/providers/dns/tf_zone_test.go
+++ b/pkg/providers/dns/tf_zone_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/dns"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/dns"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/providers/edgeworkers/create_edgekv.go
+++ b/pkg/providers/edgeworkers/create_edgekv.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/edgeworkers"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/edgeworkers"
 	"github.com/akamai/cli-terraform/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli-terraform/pkg/tools"

--- a/pkg/providers/edgeworkers/create_edgekv_test.go
+++ b/pkg/providers/edgeworkers/create_edgekv_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/edgeworkers"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/edgeworkers"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli-terraform/pkg/tools"
 	"github.com/akamai/cli/pkg/terminal"

--- a/pkg/providers/edgeworkers/create_edgeworker.go
+++ b/pkg/providers/edgeworkers/create_edgeworker.go
@@ -12,7 +12,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/edgeworkers"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/edgeworkers"
 	"github.com/akamai/cli-terraform/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli-terraform/pkg/tools"

--- a/pkg/providers/edgeworkers/create_edgeworker_test.go
+++ b/pkg/providers/edgeworkers/create_edgeworker_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/edgeworkers"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/edgeworkers"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli-terraform/pkg/tools"
 	"github.com/akamai/cli/pkg/terminal"

--- a/pkg/providers/gtm/create_domain.go
+++ b/pkg/providers/gtm/create_domain.go
@@ -128,9 +128,10 @@ func CmdCreateDomain(c *cli.Context) error {
 		TemplatesFS:     templateFiles,
 		TemplateTargets: templateToFile,
 		AdditionalFuncs: template.FuncMap{
-			"normalize":   normalizeResourceName,
-			"toUpper":     strings.ToUpper,
-			"isDefaultDC": isDefaultDatacenter,
+			"normalize":    normalizeResourceName,
+			"toUpper":      strings.ToUpper,
+			"isDefaultDC":  isDefaultDatacenter,
+			"escapeString": tools.EscapeQuotedStringLit,
 		},
 	}
 

--- a/pkg/providers/gtm/create_domain.go
+++ b/pkg/providers/gtm/create_domain.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/gtm"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/gtm"
 	"github.com/akamai/cli-terraform/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli-terraform/pkg/tools"

--- a/pkg/providers/gtm/create_domain_test.go
+++ b/pkg/providers/gtm/create_domain_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/gtm"
 	"github.com/akamai/cli-terraform/pkg/templates"
+	"github.com/akamai/cli-terraform/pkg/tools"
 	"github.com/akamai/cli/pkg/terminal"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -819,7 +820,7 @@ func TestProcessDomainTemplates(t *testing.T) {
 						StaticRRSets: []*gtm.StaticRRSet{
 							{
 								Type:  "test type",
-								Rdata: []string{"rdata1", "rdata2"},
+								Rdata: []string{"rdata1", "rdata2", "\"properlyescaped\""},
 							},
 						},
 						TrafficTargets: []*gtm.TrafficTarget{
@@ -1014,9 +1015,10 @@ func TestProcessDomainTemplates(t *testing.T) {
 					"variables.tmpl":   filepath.Join(outDir, "variables.tf"),
 				},
 				AdditionalFuncs: template.FuncMap{
-					"normalize":   normalizeResourceName,
-					"toUpper":     strings.ToUpper,
-					"isDefaultDC": isDefaultDatacenter,
+					"normalize":    normalizeResourceName,
+					"toUpper":      strings.ToUpper,
+					"isDefaultDC":  isDefaultDatacenter,
+					"escapeString": tools.EscapeQuotedStringLit,
 				},
 			}
 			require.NoError(t, processor.ProcessTemplates(test.givenData))

--- a/pkg/providers/gtm/create_domain_test.go
+++ b/pkg/providers/gtm/create_domain_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/gtm"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/gtm"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli-terraform/pkg/tools"
 	"github.com/akamai/cli/pkg/terminal"

--- a/pkg/providers/gtm/templates/properties.tmpl
+++ b/pkg/providers/gtm/templates/properties.tmpl
@@ -25,7 +25,7 @@ resource "akamai_gtm_property" "{{normalize .Name}}" {
         ttl = {{.TTL}}
         {{- end}}
         {{- if .Rdata}}
-        rdata = [{{range $i, $v := .Rdata}}{{if $i}}, {{end}}"{{$v}}"{{end}}]
+        rdata = [{{range $i, $v := .Rdata}}{{if $i}}, {{end}}"{{$v | escapeString}}"{{end}}]
         {{- end}}
     }
     {{- end}}

--- a/pkg/providers/gtm/testdata/with_properties/properties.tf
+++ b/pkg/providers/gtm/testdata/with_properties/properties.tf
@@ -48,7 +48,7 @@ resource "akamai_gtm_property" "test_property2" {
   balance_by_download_score   = false
   static_rr_set {
     type  = "test type"
-    rdata = ["rdata1", "rdata2"]
+    rdata = ["rdata1", "rdata2", "\"properlyescaped\""]
   }
   dynamic_ttl            = 60
   handout_limit          = 8

--- a/pkg/providers/iam/create_iam.go
+++ b/pkg/providers/iam/create_iam.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/iam"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/iam"
 	"github.com/akamai/cli/pkg/terminal"
 	"github.com/urfave/cli/v2"
 )

--- a/pkg/providers/iam/create_iam_all.go
+++ b/pkg/providers/iam/create_iam_all.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/iam"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/iam"
 	"github.com/akamai/cli-terraform/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli-terraform/pkg/tools"

--- a/pkg/providers/iam/create_iam_all_test.go
+++ b/pkg/providers/iam/create_iam_all_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/iam"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/iam"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli-terraform/pkg/tools"
 	"github.com/akamai/cli/pkg/terminal"

--- a/pkg/providers/iam/create_iam_group.go
+++ b/pkg/providers/iam/create_iam_group.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/iam"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/iam"
 	"github.com/akamai/cli-terraform/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli-terraform/pkg/tools"

--- a/pkg/providers/iam/create_iam_group_test.go
+++ b/pkg/providers/iam/create_iam_group_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/iam"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/iam"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli-terraform/pkg/tools"
 	"github.com/akamai/cli/pkg/terminal"

--- a/pkg/providers/iam/create_iam_role.go
+++ b/pkg/providers/iam/create_iam_role.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/iam"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/iam"
 	"github.com/akamai/cli-terraform/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli-terraform/pkg/tools"

--- a/pkg/providers/iam/create_iam_role_test.go
+++ b/pkg/providers/iam/create_iam_role_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/iam"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/iam"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli-terraform/pkg/tools"
 	"github.com/akamai/cli/pkg/terminal"

--- a/pkg/providers/iam/create_iam_test.go
+++ b/pkg/providers/iam/create_iam_test.go
@@ -3,7 +3,7 @@ package iam
 import (
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/iam"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/iam"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/providers/iam/create_iam_user.go
+++ b/pkg/providers/iam/create_iam_user.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/iam"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/iam"
 	"github.com/akamai/cli-terraform/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli-terraform/pkg/tools"

--- a/pkg/providers/iam/create_iam_user_test.go
+++ b/pkg/providers/iam/create_iam_user_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/iam"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/iam"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli-terraform/pkg/tools"
 	"github.com/akamai/cli/pkg/terminal"

--- a/pkg/providers/imaging/create_imaging.go
+++ b/pkg/providers/imaging/create_imaging.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/imaging"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/imaging"
 	"github.com/akamai/cli-terraform/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli-terraform/pkg/tools"

--- a/pkg/providers/imaging/create_imaging_test.go
+++ b/pkg/providers/imaging/create_imaging_test.go
@@ -13,8 +13,8 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/imaging"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/tools"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/imaging"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/tools"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli/pkg/terminal"
 	"github.com/stretchr/testify/assert"

--- a/pkg/providers/papi/create_include.go
+++ b/pkg/providers/papi/create_include.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/papi"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/papi"
 	"github.com/akamai/cli-terraform/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli-terraform/pkg/tools"

--- a/pkg/providers/papi/create_include_test.go
+++ b/pkg/providers/papi/create_include_test.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/papi"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/tools"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/papi"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/tools"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli/pkg/terminal"
 	"github.com/stretchr/testify/assert"

--- a/pkg/providers/papi/create_property.go
+++ b/pkg/providers/papi/create_property.go
@@ -30,8 +30,8 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/hapi"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/papi"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/hapi"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/papi"
 	"github.com/akamai/cli-terraform/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli-terraform/pkg/tools"

--- a/pkg/providers/papi/create_property_test.go
+++ b/pkg/providers/papi/create_property_test.go
@@ -470,7 +470,6 @@ func TestCreateProperty(t *testing.T) {
 		UseDefaultTTL:     false,
 		UseDefaultMap:     false,
 		IPVersionBehavior: "IPV6_IPV4_DUALSTACK",
-		ProductID:         "",
 		TTL:               21600,
 		Map:               "a;test.akamai.net",
 		SerialNumber:      1461,

--- a/pkg/providers/papi/create_property_test.go
+++ b/pkg/providers/papi/create_property_test.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/hapi"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v5/pkg/papi"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/hapi"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v6/pkg/papi"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli-terraform/pkg/tools"
 	"github.com/akamai/cli/pkg/terminal"

--- a/pkg/providers/papi/create_property_test.go
+++ b/pkg/providers/papi/create_property_test.go
@@ -1252,7 +1252,7 @@ func TestProcessPolicyTemplates(t *testing.T) {
 			dir:          "basic-rules-datasource-unknown",
 			schema:       true,
 			filesToCheck: []string{"property.tf", "rules.tf", "variables.tf", "import.sh"},
-			withError:    "there were errors reported: Unknown criterion 'matchAdvanced-unsupported', Unknown behavior 'caching-unknown', Unknown behavior 'allowPost-unknown'",
+			withError:    "there were errors reported: Unknown behavior 'caching-unknown', Unknown behavior 'allowPost-unknown'",
 		},
 		"property with include": {
 			givenData: TFData{

--- a/pkg/providers/papi/templates/includes.tmpl
+++ b/pkg/providers/papi/templates/includes.tmpl
@@ -1,3 +1,4 @@
+{{- /*gotype: github.com/akamai/cli-terraform/pkg/providers/papi.TFData*/ -}}
 {{- if not .Property.PropertyID -}}
 terraform {
   required_providers {
@@ -16,12 +17,14 @@ provider "akamai" {
 
 {{ end }}
 {{- range $include := .Includes }}
+{{- if not $.RulesAsSchema}}
 data "akamai_property_rules_template" "rules_{{.IncludeName}}" {
   template_file = abspath("${path.module}/property-snippets/{{.IncludeName}}.json")
 }
+{{- end}}
 
 /*
-data "akamai_property_include_parents" "include_parents" {
+data "akamai_property_include_parents" "{{.IncludeName}}" {
   contract_id = "{{.ContractID}}"
   group_id    = "{{.GroupID}}"
   include_id  = "{{.IncludeID}}"
@@ -32,9 +35,18 @@ resource "akamai_property_include" "{{.IncludeName}}" {
   contract_id = "{{.ContractID}}"
   group_id = "{{.GroupID}}"
   name = "{{.IncludeName}}"
-  rule_format = "{{.RuleFormat}}"
   type = "{{.IncludeType}}"
+{{- if $.RulesAsSchema}}
+{{- if .Rules}}
+  rule_format = data.akamai_property_rules_builder.{{(index .Rules 0).TerraformName}}.rule_format
+  rules       = data.akamai_property_rules_builder.{{(index .Rules 0).TerraformName}}.json
+{{- else}}
+  rule_format = "{{.RuleFormat}}"
+{{- end}}
+{{- else}}
+  rule_format = "{{.RuleFormat}}"
   rules = data.akamai_property_rules_template.rules_{{.IncludeName}}.json
+{{- end}}
 }
 {{- range $network := .Networks}}
 

--- a/pkg/providers/papi/templates/includes_rules.tmpl
+++ b/pkg/providers/papi/templates/includes_rules.tmpl
@@ -1,0 +1,6 @@
+{{- /*gotype: github.com/akamai/cli-terraform/pkg/providers/papi.TFData*/ -}}
+{{- if $.RulesAsSchema}}
+{{- range .Includes }}
+{{- template "rules_builder" .}}
+{{- end}}
+{{- end}}

--- a/pkg/providers/papi/templates/property.tmpl
+++ b/pkg/providers/papi/templates/property.tmpl
@@ -1,3 +1,4 @@
+{{- /*gotype: github.com/akamai/cli-terraform/pkg/providers/papi.TFData*/ -}}
 terraform {
   required_providers {
     akamai = {

--- a/pkg/providers/papi/templates/rules_v2023-01-05.tmpl
+++ b/pkg/providers/papi/templates/rules_v2023-01-05.tmpl
@@ -9494,8 +9494,10 @@ data "akamai_property_rules_builder" "{{$r.TerraformName}}" {
         {{- if .Comments}}
         comments = {{template "Text" .Comments}}
         {{- end}}
+		{{- if ne $i 0}}
 		{{- if .CriteriaMustSatisfy}}
         criteria_must_satisfy = "{{.CriteriaMustSatisfy}}"
+        {{- end}}
         {{- end}}
         {{- if .UUID}}
         uuid = "{{.UUID}}"
@@ -9506,9 +9508,11 @@ data "akamai_property_rules_builder" "{{$r.TerraformName}}" {
         {{- if .TemplateLink}}
         template_link = "{{.TemplateLink}}"
         {{- end}}
+		{{- if ne $i 0}}
         {{- if .CriteriaLocked}}
         criteria_locked = "{{.CriteriaLocked}}"
         {{- end}}
+		{{- end}}
 {{- if eq $i 0}}
 {{- range .Variables}}
         variable {
@@ -9529,10 +9533,12 @@ data "akamai_property_rules_builder" "{{$r.TerraformName}}" {
 		}
 		{{- end}}
 {{- end}}
+{{- if ne $i 0}}
 {{- range .Criteria}}
         criterion {
 {{- template "Criteria" .}}
         }
+{{- end}}
 {{- end}}
 {{- range .Behaviors}}
         behavior {

--- a/pkg/providers/papi/templates/rules_v2023-01-05.tmpl
+++ b/pkg/providers/papi/templates/rules_v2023-01-05.tmpl
@@ -9481,7 +9481,7 @@ visitor_prioritization_request {
 {{- end}}
 }
 {{- end}}
-
+{{- define "rules_builder"}}
 {{- range $i, $r := .Rules}}
 data "akamai_property_rules_builder" "{{$r.TerraformName}}" {
 	{{- $children := $r.Children}}
@@ -9554,4 +9554,6 @@ data "akamai_property_rules_builder" "{{$r.TerraformName}}" {
 	{{- end}}
 }
 {{end -}}
-{{CheckErrors -}}
+{{- end}}
+{{- template "rules_builder" .}}
+{{- CheckErrors -}}

--- a/pkg/providers/papi/templates/variables.tmpl
+++ b/pkg/providers/papi/templates/variables.tmpl
@@ -1,3 +1,4 @@
+{{- /*gotype: github.com/akamai/cli-terraform/pkg/providers/papi.TFData*/ -}}
 variable "edgerc_path" {
   type = string
   default = "~/.edgerc"

--- a/pkg/providers/papi/testdata/basic-rules-datasource-unknown/mock_rules.json
+++ b/pkg/providers/papi/testdata/basic-rules-datasource-unknown/mock_rules.json
@@ -33,33 +33,8 @@
         }
       }
     ],
-    "criteria": [
-      {
-        "name": "matchAdvanced-unsupported",
-        "options": {
-          "description": "",
-          "openXml": "",
-          "closeXml": ""
-        },
-        "uuid": "fa27bc4d-bfff-4541-8eb7-ade156a57256"
-      },
-      {
-        "name": "contentType",
-        "options": {
-          "matchCaseSensitive": false,
-          "matchOperator": "IS_ONE_OF",
-          "matchWildcard": true,
-          "values": [
-            "text/html*",
-            "text/css*",
-            "application/x-javascript*"
-          ]
-        }
-      }
-    ],
     "name": "default",
     "options": {},
-    "uuid": "default",
-    "criteriaMustSatisfy": "all"
+    "uuid": "default"
   }
 }

--- a/pkg/providers/papi/testdata/basic-rules-datasource/mock_rules.json
+++ b/pkg/providers/papi/testdata/basic-rules-datasource/mock_rules.json
@@ -151,30 +151,6 @@
         }
       }
     ],
-    "criteria": [
-      {
-        "name": "matchAdvanced",
-        "options": {
-          "description": "",
-          "openXml": "",
-          "closeXml": ""
-        },
-        "uuid": "fa27bc4d-bfff-4541-8eb7-ade156a57256"
-      },
-      {
-        "name": "contentType",
-        "options": {
-          "matchCaseSensitive": false,
-          "matchOperator": "IS_ONE_OF",
-          "matchWildcard": true,
-          "values": [
-            "text/html*",
-            "text/css*",
-            "application/x-javascript*"
-          ]
-        }
-      }
-    ],
     "children": [
       {
         "behaviors": [

--- a/pkg/providers/papi/testdata/basic-rules-datasource/rules.tf
+++ b/pkg/providers/papi/testdata/basic-rules-datasource/rules.tf
@@ -1,10 +1,9 @@
 
 data "akamai_property_rules_builder" "test-edgesuite-net_rule_default" {
   rules_v2023_01_05 {
-    name                  = "default"
-    is_secure             = false
-    criteria_must_satisfy = "all"
-    uuid                  = "default"
+    name      = "default"
+    is_secure = false
+    uuid      = "default"
     variable {
       name        = "PMUSER_TESTSTR"
       description = "DSTR"
@@ -28,22 +27,6 @@ EOT
     custom_override {
       name        = "mdc"
       override_id = "cbo_12345"
-    }
-    criterion {
-      match_advanced {
-        uuid        = "fa27bc4d-bfff-4541-8eb7-ade156a57256"
-        close_xml   = ""
-        description = ""
-        open_xml    = ""
-      }
-    }
-    criterion {
-      content_type {
-        match_case_sensitive = false
-        match_operator       = "IS_ONE_OF"
-        match_wildcard       = true
-        values               = ["text/html*", "text/css*", "application/x-javascript*", ]
-      }
     }
     behavior {
       application_load_balancer {

--- a/pkg/providers/papi/testdata/basic_property_with_include/includes.tf
+++ b/pkg/providers/papi/testdata/basic_property_with_include/includes.tf
@@ -4,7 +4,7 @@ data "akamai_property_rules_template" "rules_test_include" {
 }
 
 /*
-data "akamai_property_include_parents" "include_parents" {
+data "akamai_property_include_parents" "test_include" {
   contract_id = "test_contract"
   group_id    = "test_group"
   include_id  = "inc_123456"
@@ -15,8 +15,8 @@ resource "akamai_property_include" "test_include" {
   contract_id = "test_contract"
   group_id    = "test_group"
   name        = "test_include"
-  rule_format = "v2020-11-02"
   type        = "MICROSERVICES"
+  rule_format = "v2020-11-02"
   rules       = data.akamai_property_rules_template.rules_test_include.json
 }
 

--- a/pkg/providers/papi/testdata/basic_property_with_multiple_includes/includes.tf
+++ b/pkg/providers/papi/testdata/basic_property_with_multiple_includes/includes.tf
@@ -4,7 +4,7 @@ data "akamai_property_rules_template" "rules_test_include" {
 }
 
 /*
-data "akamai_property_include_parents" "include_parents" {
+data "akamai_property_include_parents" "test_include" {
   contract_id = "test_contract"
   group_id    = "test_group"
   include_id  = "inc_123456"
@@ -15,8 +15,8 @@ resource "akamai_property_include" "test_include" {
   contract_id = "test_contract"
   group_id    = "test_group"
   name        = "test_include"
-  rule_format = "v2020-11-02"
   type        = "MICROSERVICES"
+  rule_format = "v2020-11-02"
   rules       = data.akamai_property_rules_template.rules_test_include.json
 }
 
@@ -46,7 +46,7 @@ data "akamai_property_rules_template" "rules_test_include_1" {
 }
 
 /*
-data "akamai_property_include_parents" "include_parents" {
+data "akamai_property_include_parents" "test_include_1" {
   contract_id = "test_contract"
   group_id    = "test_group"
   include_id  = "inc_78910"
@@ -57,8 +57,8 @@ resource "akamai_property_include" "test_include_1" {
   contract_id = "test_contract"
   group_id    = "test_group"
   name        = "test_include_1"
-  rule_format = "v2020-11-02"
   type        = "MICROSERVICES"
+  rule_format = "v2020-11-02"
   rules       = data.akamai_property_rules_template.rules_test_include_1.json
 }
 

--- a/pkg/providers/papi/testdata/basic_property_with_multiple_includes_schema/import.sh
+++ b/pkg/providers/papi/testdata/basic_property_with_multiple_includes_schema/import.sh
@@ -1,0 +1,8 @@
+terraform init
+terraform import akamai_edge_hostname.test-edgesuite-net ehn_2867480,test_contract,grp_12345
+terraform import akamai_property.test-edgesuite-net prp_12345,test_contract,grp_12345,LATEST
+terraform import akamai_property_include.test_include test_contract:test_group:inc_123456
+terraform import akamai_property_include_activation.test_include_staging test_contract:test_group:inc_123456:STAGING
+terraform import akamai_property_include_activation.test_include_production test_contract:test_group:inc_123456:PRODUCTION
+terraform import akamai_property_include.test_include_1 test_contract:test_group:inc_78910
+terraform import akamai_property_include_activation.test_include_1_staging test_contract:test_group:inc_78910:STAGING

--- a/pkg/providers/papi/testdata/basic_property_with_multiple_includes_schema/includes.tf
+++ b/pkg/providers/papi/testdata/basic_property_with_multiple_includes_schema/includes.tf
@@ -1,22 +1,4 @@
-terraform {
-  required_providers {
-    akamai = {
-      source  = "akamai/akamai"
-      version = ">= 3.2.0"
-    }
-  }
-  required_version = ">= 0.13"
-}
 
-provider "akamai" {
-  edgerc         = var.edgerc_path
-  config_section = var.config_section
-}
-
-
-data "akamai_property_rules_template" "rules_test_include" {
-  template_file = abspath("${path.module}/property-snippets/test_include.json")
-}
 
 /*
 data "akamai_property_include_parents" "test_include" {
@@ -31,8 +13,8 @@ resource "akamai_property_include" "test_include" {
   group_id    = "test_group"
   name        = "test_include"
   type        = "MICROSERVICES"
-  rule_format = "v2020-11-02"
-  rules       = data.akamai_property_rules_template.rules_test_include.json
+  rule_format = data.akamai_property_rules_builder.test_include_rule_default.rule_format
+  rules       = data.akamai_property_rules_builder.test_include_rule_default.json
 }
 
 resource "akamai_property_include_activation" "test_include_staging" {
@@ -55,4 +37,32 @@ resource "akamai_property_include_activation" "test_include_production" {
   version                        = "1"
   note                           = "test production activation"
   notify_emails                  = ["test@example.com", "test1@example.com"]
+}
+
+/*
+data "akamai_property_include_parents" "test_include_1" {
+  contract_id = "test_contract"
+  group_id    = "test_group"
+  include_id  = "inc_78910"
+}
+*/
+
+resource "akamai_property_include" "test_include_1" {
+  contract_id = "test_contract"
+  group_id    = "test_group"
+  name        = "test_include_1"
+  type        = "MICROSERVICES"
+  rule_format = data.akamai_property_rules_builder.test_include_1_rule_default.rule_format
+  rules       = data.akamai_property_rules_builder.test_include_1_rule_default.json
+}
+
+resource "akamai_property_include_activation" "test_include_1_staging" {
+  contract_id                    = akamai_property_include.test_include_1.contract_id
+  group_id                       = akamai_property_include.test_include_1.group_id
+  include_id                     = akamai_property_include.test_include_1.id
+  network                        = "STAGING"
+  auto_acknowledge_rule_warnings = false
+  version                        = "1"
+  note                           = "test staging activation"
+  notify_emails                  = ["test@example.com"]
 }

--- a/pkg/providers/papi/testdata/basic_property_with_multiple_includes_schema/includes_rules.tf
+++ b/pkg/providers/papi/testdata/basic_property_with_multiple_includes_schema/includes_rules.tf
@@ -1,0 +1,328 @@
+
+data "akamai_property_rules_builder" "test_include_rule_default" {
+  rules_v2023_01_05 {
+    name      = "default"
+    is_secure = false
+    uuid      = "default"
+    behavior {
+      origin {
+        cache_key_hostname    = "ORIGIN_HOSTNAME"
+        compress              = true
+        enable_true_client_ip = false
+        forward_host_header   = "REQUEST_HOST_HEADER"
+        hostname              = "1.2.3.4"
+        http_port             = 80
+        https_port            = 443
+        origin_sni            = false
+        origin_type           = "CUSTOMER"
+        use_unique_cache_key  = false
+        verification_mode     = "PLATFORM_SETTINGS"
+      }
+    }
+    behavior {
+      cp_code {
+        value {
+          created_date = 1506429558000
+          description  = "Test-NewHire"
+          id           = 626358
+          name         = "Test-NewHire"
+          products     = ["Site_Defender", ]
+        }
+      }
+    }
+    behavior {
+      caching {
+        behavior = "NO_STORE"
+      }
+    }
+    behavior {
+      allow_post {
+        allow_without_content_length = false
+        enabled                      = true
+      }
+    }
+    behavior {
+      report {
+        log_accept_language  = false
+        log_cookies          = "OFF"
+        log_custom_log_field = false
+        log_host             = false
+        log_referer          = false
+        log_user_agent       = true
+      }
+    }
+    behavior {
+      advanced {
+        uuid        = "feeaeff9-fe7e-4e27-ba0c-7b1dcecdba8b"
+        description = "extract inputs"
+        xml = trimsuffix(<<EOT
+<assign:extract-value>
+   <variable-name>ENDUSER</variable-name>
+   <location>Query_String</location>
+   <location-id>enduser</location-id>
+   <separator>=</separator>
+</assign:extract-value>
+<assign:extract-value>
+   <variable-name>GHOST</variable-name>
+   <location>Query_String</location>
+   <location-id>ghost</location-id>
+   <separator>=</separator>
+</assign:extract-value>
+
+<assign:variable>
+   <name>DISTANCE</name>
+   <transform>
+      <geo-distance>
+         <ip1>%(ENDUSER)</ip1>
+         <ip2>%(GHOST)</ip2>
+      </geo-distance>
+   </transform>
+</assign:variable>
+
+
+
+<edgeservices:construct-response>
+   <status>on</status>
+   <http-status>200</http-status>
+   <body>%(DISTANCE)</body>
+   <force-cache-eviction>off</force-cache-eviction>
+</edgeservices:construct-response>
+
+<edgeservices:modify-outgoing-response.add-header>
+      <name>Distance</name>
+      <value>%(DISTANCE)</value>
+   </edgeservices:modify-outgoing-response.add-header>
+EOT
+        , "\n")
+      }
+    }
+    children = [
+      data.akamai_property_rules_builder.test_include_rule_content_compression.json,
+      data.akamai_property_rules_builder.test_include_rule_static_content.json,
+      data.akamai_property_rules_builder.test_include_rule_dynamic_content.json,
+    ]
+  }
+}
+
+data "akamai_property_rules_builder" "test_include_rule_content_compression" {
+  rules_v2023_01_05 {
+    name                  = "Content Compression"
+    criteria_must_satisfy = "all"
+    criterion {
+      content_type {
+        match_case_sensitive = false
+        match_operator       = "IS_ONE_OF"
+        match_wildcard       = true
+        values               = ["text/html*", "text/css*", "application/x-javascript*", ]
+      }
+    }
+    behavior {
+      gzip_response {
+        behavior = "ALWAYS"
+      }
+    }
+  }
+}
+
+data "akamai_property_rules_builder" "test_include_rule_static_content" {
+  rules_v2023_01_05 {
+    name                  = "Static Content"
+    criteria_must_satisfy = "all"
+    criterion {
+      file_extension {
+        match_case_sensitive = false
+        match_operator       = "IS_ONE_OF"
+        values               = ["aif", "aiff", "au", "avi", "bin", "bmp", "cab", "carb", "cct", "cdf", "class", "css", "doc", "dcr", "dtd", "exe", "flv", "gcf", "gff", "gif", "grv", "hdml", "hqx", "ico", "ini", "jpeg", "jpg", "js", "mov", "mp3", "nc", "pct", "pdf", "png", "ppc", "pws", "swa", "swf", "txt", "vbs", "w32", "wav", "wbmp", "wml", "wmlc", "wmls", "wmlsc", "xsd", "zip", "webp", "jxr", "hdp", "wdp", "pict", "tif", "tiff", "mid", "midi", "ttf", "eot", "woff", "otf", "svg", "svgz", "jar", "woff2", ]
+      }
+    }
+    behavior {
+      caching {
+        behavior        = "MAX_AGE"
+        must_revalidate = false
+        ttl             = "1d"
+      }
+    }
+  }
+}
+
+data "akamai_property_rules_builder" "test_include_rule_dynamic_content" {
+  rules_v2023_01_05 {
+    name                  = "Dynamic Content"
+    criteria_must_satisfy = "all"
+    criterion {
+      cacheability {
+        match_operator = "IS_NOT"
+        value          = "CACHEABLE"
+      }
+    }
+    behavior {
+      downstream_cache {
+        behavior = "TUNNEL_ORIGIN"
+      }
+    }
+  }
+}
+
+data "akamai_property_rules_builder" "test_include_1_rule_default" {
+  rules_v2023_01_05 {
+    name      = "default"
+    is_secure = false
+    uuid      = "default"
+    behavior {
+      origin {
+        cache_key_hostname    = "ORIGIN_HOSTNAME"
+        compress              = true
+        enable_true_client_ip = false
+        forward_host_header   = "REQUEST_HOST_HEADER"
+        hostname              = "1.2.3.4"
+        http_port             = 80
+        https_port            = 443
+        origin_sni            = false
+        origin_type           = "CUSTOMER"
+        use_unique_cache_key  = false
+        verification_mode     = "PLATFORM_SETTINGS"
+      }
+    }
+    behavior {
+      cp_code {
+        value {
+          created_date = 1506429558000
+          description  = "Test-NewHire"
+          id           = 626358
+          name         = "Test-NewHire"
+          products     = ["Site_Defender", ]
+        }
+      }
+    }
+    behavior {
+      caching {
+        behavior = "NO_STORE"
+      }
+    }
+    behavior {
+      allow_post {
+        allow_without_content_length = false
+        enabled                      = true
+      }
+    }
+    behavior {
+      report {
+        log_accept_language  = false
+        log_cookies          = "OFF"
+        log_custom_log_field = false
+        log_host             = false
+        log_referer          = false
+        log_user_agent       = true
+      }
+    }
+    behavior {
+      advanced {
+        uuid        = "feeaeff9-fe7e-4e27-ba0c-7b1dcecdba8b"
+        description = "extract inputs"
+        xml = trimsuffix(<<EOT
+<assign:extract-value>
+   <variable-name>ENDUSER</variable-name>
+   <location>Query_String</location>
+   <location-id>enduser</location-id>
+   <separator>=</separator>
+</assign:extract-value>
+<assign:extract-value>
+   <variable-name>GHOST</variable-name>
+   <location>Query_String</location>
+   <location-id>ghost</location-id>
+   <separator>=</separator>
+</assign:extract-value>
+
+<assign:variable>
+   <name>DISTANCE</name>
+   <transform>
+      <geo-distance>
+         <ip1>%(ENDUSER)</ip1>
+         <ip2>%(GHOST)</ip2>
+      </geo-distance>
+   </transform>
+</assign:variable>
+
+
+
+<edgeservices:construct-response>
+   <status>on</status>
+   <http-status>200</http-status>
+   <body>%(DISTANCE)</body>
+   <force-cache-eviction>off</force-cache-eviction>
+</edgeservices:construct-response>
+
+<edgeservices:modify-outgoing-response.add-header>
+      <name>Distance</name>
+      <value>%(DISTANCE)</value>
+   </edgeservices:modify-outgoing-response.add-header>
+EOT
+        , "\n")
+      }
+    }
+    children = [
+      data.akamai_property_rules_builder.test_include_1_rule_content_compression.json,
+      data.akamai_property_rules_builder.test_include_1_rule_static_content.json,
+      data.akamai_property_rules_builder.test_include_1_rule_dynamic_content.json,
+    ]
+  }
+}
+
+data "akamai_property_rules_builder" "test_include_1_rule_content_compression" {
+  rules_v2023_01_05 {
+    name                  = "Content Compression"
+    criteria_must_satisfy = "all"
+    criterion {
+      content_type {
+        match_case_sensitive = false
+        match_operator       = "IS_ONE_OF"
+        match_wildcard       = true
+        values               = ["text/html*", "text/css*", "application/x-javascript*", ]
+      }
+    }
+    behavior {
+      gzip_response {
+        behavior = "ALWAYS"
+      }
+    }
+  }
+}
+
+data "akamai_property_rules_builder" "test_include_1_rule_static_content" {
+  rules_v2023_01_05 {
+    name                  = "Static Content"
+    criteria_must_satisfy = "all"
+    criterion {
+      file_extension {
+        match_case_sensitive = false
+        match_operator       = "IS_ONE_OF"
+        values               = ["aif", "aiff", "au", "avi", "bin", "bmp", "cab", "carb", "cct", "cdf", "class", "css", "doc", "dcr", "dtd", "exe", "flv", "gcf", "gff", "gif", "grv", "hdml", "hqx", "ico", "ini", "jpeg", "jpg", "js", "mov", "mp3", "nc", "pct", "pdf", "png", "ppc", "pws", "swa", "swf", "txt", "vbs", "w32", "wav", "wbmp", "wml", "wmlc", "wmls", "wmlsc", "xsd", "zip", "webp", "jxr", "hdp", "wdp", "pict", "tif", "tiff", "mid", "midi", "ttf", "eot", "woff", "otf", "svg", "svgz", "jar", "woff2", ]
+      }
+    }
+    behavior {
+      caching {
+        behavior        = "MAX_AGE"
+        must_revalidate = false
+        ttl             = "1d"
+      }
+    }
+  }
+}
+
+data "akamai_property_rules_builder" "test_include_1_rule_dynamic_content" {
+  rules_v2023_01_05 {
+    name                  = "Dynamic Content"
+    criteria_must_satisfy = "all"
+    criterion {
+      cacheability {
+        match_operator = "IS_NOT"
+        value          = "CACHEABLE"
+      }
+    }
+    behavior {
+      downstream_cache {
+        behavior = "TUNNEL_ORIGIN"
+      }
+    }
+  }
+}

--- a/pkg/providers/papi/testdata/basic_property_with_multiple_includes_schema/mock_include_rules.json
+++ b/pkg/providers/papi/testdata/basic_property_with_multiple_includes_schema/mock_include_rules.json
@@ -1,0 +1,223 @@
+{
+  "accountId": "test_account",
+  "contractId": "test_contract",
+  "groupId": "test_group",
+  "includeId": "inc_123456",
+  "includeVersion": 2,
+  "includeType": "MICROSERVICES",
+  "etag": "4607f363da8bc05b0c0f0f7524985d2fbc5d864d",
+  "ruleFormat": "v2023-01-05",
+  "rules": {
+    "behaviors": [
+      {
+        "name": "origin",
+        "options": {
+          "cacheKeyHostname": "ORIGIN_HOSTNAME",
+          "compress": true,
+          "enableTrueClientIp": false,
+          "forwardHostHeader": "REQUEST_HOST_HEADER",
+          "hostname": "1.2.3.4",
+          "httpPort": 80,
+          "httpsPort": 443,
+          "originSni": false,
+          "originType": "CUSTOMER",
+          "useUniqueCacheKey": false,
+          "verificationMode": "PLATFORM_SETTINGS"
+        }
+      },
+      {
+        "name": "cpCode",
+        "options": {
+          "value": {
+            "createdDate": 1506429558000,
+            "description": "Test-NewHire",
+            "id": 626358,
+            "name": "Test-NewHire",
+            "products": [
+              "Site_Defender"
+            ]
+          }
+        }
+      },
+      {
+        "name": "caching",
+        "options": {
+          "behavior": "NO_STORE"
+        }
+      },
+      {
+        "name": "allowPost",
+        "options": {
+          "allowWithoutContentLength": false,
+          "enabled": true
+        }
+      },
+      {
+        "name": "report",
+        "options": {
+          "logAcceptLanguage": false,
+          "logCookies": "OFF",
+          "logCustomLogField": false,
+          "logHost": false,
+          "logReferer": false,
+          "logUserAgent": true
+        }
+      },
+      {
+        "name": "advanced",
+        "options": {
+          "description": "extract inputs",
+          "xml": "\u003cassign:extract-value\u003e\n   \u003cvariable-name\u003eENDUSER\u003c/variable-name\u003e\n   \u003clocation\u003eQuery_String\u003c/location\u003e\n   \u003clocation-id\u003eenduser\u003c/location-id\u003e\n   \u003cseparator\u003e=\u003c/separator\u003e\n\u003c/assign:extract-value\u003e\n\u003cassign:extract-value\u003e\n   \u003cvariable-name\u003eGHOST\u003c/variable-name\u003e\n   \u003clocation\u003eQuery_String\u003c/location\u003e\n   \u003clocation-id\u003eghost\u003c/location-id\u003e\n   \u003cseparator\u003e=\u003c/separator\u003e\n\u003c/assign:extract-value\u003e\n\n\u003cassign:variable\u003e\n   \u003cname\u003eDISTANCE\u003c/name\u003e\n   \u003ctransform\u003e\n      \u003cgeo-distance\u003e\n         \u003cip1\u003e%(ENDUSER)\u003c/ip1\u003e\n         \u003cip2\u003e%(GHOST)\u003c/ip2\u003e\n      \u003c/geo-distance\u003e\n   \u003c/transform\u003e\n\u003c/assign:variable\u003e\n\n\n\n\u003cedgeservices:construct-response\u003e\n   \u003cstatus\u003eon\u003c/status\u003e\n   \u003chttp-status\u003e200\u003c/http-status\u003e\n   \u003cbody\u003e%(DISTANCE)\u003c/body\u003e\n   \u003cforce-cache-eviction\u003eoff\u003c/force-cache-eviction\u003e\n\u003c/edgeservices:construct-response\u003e\n\n\u003cedgeservices:modify-outgoing-response.add-header\u003e\n      \u003cname\u003eDistance\u003c/name\u003e\n      \u003cvalue\u003e%(DISTANCE)\u003c/value\u003e\n   \u003c/edgeservices:modify-outgoing-response.add-header\u003e"
+        },
+        "uuid": "feeaeff9-fe7e-4e27-ba0c-7b1dcecdba8b"
+      }
+    ],
+    "children": [
+      {
+        "behaviors": [
+          {
+            "name": "gzipResponse",
+            "options": {
+              "behavior": "ALWAYS"
+            }
+          }
+        ],
+        "criteria": [
+          {
+            "name": "contentType",
+            "options": {
+              "matchCaseSensitive": false,
+              "matchOperator": "IS_ONE_OF",
+              "matchWildcard": true,
+              "values": [
+                "text/html*",
+                "text/css*",
+                "application/x-javascript*"
+              ]
+            }
+          }
+        ],
+        "name": "Content Compression",
+        "options": {},
+        "criteriaMustSatisfy": "all"
+      },
+      {
+        "behaviors": [
+          {
+            "name": "caching",
+            "options": {
+              "behavior": "MAX_AGE",
+              "mustRevalidate": false,
+              "ttl": "1d"
+            }
+          }
+        ],
+        "criteria": [
+          {
+            "name": "fileExtension",
+            "options": {
+              "matchCaseSensitive": false,
+              "matchOperator": "IS_ONE_OF",
+              "values": [
+                "aif",
+                "aiff",
+                "au",
+                "avi",
+                "bin",
+                "bmp",
+                "cab",
+                "carb",
+                "cct",
+                "cdf",
+                "class",
+                "css",
+                "doc",
+                "dcr",
+                "dtd",
+                "exe",
+                "flv",
+                "gcf",
+                "gff",
+                "gif",
+                "grv",
+                "hdml",
+                "hqx",
+                "ico",
+                "ini",
+                "jpeg",
+                "jpg",
+                "js",
+                "mov",
+                "mp3",
+                "nc",
+                "pct",
+                "pdf",
+                "png",
+                "ppc",
+                "pws",
+                "swa",
+                "swf",
+                "txt",
+                "vbs",
+                "w32",
+                "wav",
+                "wbmp",
+                "wml",
+                "wmlc",
+                "wmls",
+                "wmlsc",
+                "xsd",
+                "zip",
+                "webp",
+                "jxr",
+                "hdp",
+                "wdp",
+                "pict",
+                "tif",
+                "tiff",
+                "mid",
+                "midi",
+                "ttf",
+                "eot",
+                "woff",
+                "otf",
+                "svg",
+                "svgz",
+                "jar",
+                "woff2"
+              ]
+            }
+          }
+        ],
+        "name": "Static Content",
+        "options": {},
+        "criteriaMustSatisfy": "all"
+      },
+      {
+        "behaviors": [
+          {
+            "name": "downstreamCache",
+            "options": {
+              "behavior": "TUNNEL_ORIGIN"
+            }
+          }
+        ],
+        "criteria": [
+          {
+            "name": "cacheability",
+            "options": {
+              "matchOperator": "IS_NOT",
+              "value": "CACHEABLE"
+            }
+          }
+        ],
+        "name": "Dynamic Content",
+        "options": {},
+        "criteriaMustSatisfy": "all"
+      }
+    ],
+    "name": "default",
+    "options": {},
+    "uuid": "default"
+  }
+}

--- a/pkg/providers/papi/testdata/basic_property_with_multiple_includes_schema/mock_rules.json
+++ b/pkg/providers/papi/testdata/basic_property_with_multiple_includes_schema/mock_rules.json
@@ -1,0 +1,222 @@
+{
+  "accountId": "test_account",
+  "contractId": "test_contract",
+  "groupId": "grp_12345",
+  "propertyId": "prp_12345",
+  "propertyVersion": 5,
+  "etag": "4607f363da8bc05b0c0f0f7524985d2fbc5d864d",
+  "ruleFormat": "v2023-01-05",
+  "rules": {
+    "behaviors": [
+      {
+        "name": "origin",
+        "options": {
+          "cacheKeyHostname": "ORIGIN_HOSTNAME",
+          "compress": true,
+          "enableTrueClientIp": false,
+          "forwardHostHeader": "REQUEST_HOST_HEADER",
+          "hostname": "1.2.3.4",
+          "httpPort": 80,
+          "httpsPort": 443,
+          "originSni": false,
+          "originType": "CUSTOMER",
+          "useUniqueCacheKey": false,
+          "verificationMode": "PLATFORM_SETTINGS"
+        }
+      },
+      {
+        "name": "cpCode",
+        "options": {
+          "value": {
+            "createdDate": 1506429558000,
+            "description": "Test-NewHire",
+            "id": 626358,
+            "name": "Test-NewHire",
+            "products": [
+              "Site_Defender"
+            ]
+          }
+        }
+      },
+      {
+        "name": "caching",
+        "options": {
+          "behavior": "NO_STORE"
+        }
+      },
+      {
+        "name": "allowPost",
+        "options": {
+          "allowWithoutContentLength": false,
+          "enabled": true
+        }
+      },
+      {
+        "name": "report",
+        "options": {
+          "logAcceptLanguage": false,
+          "logCookies": "OFF",
+          "logCustomLogField": false,
+          "logHost": false,
+          "logReferer": false,
+          "logUserAgent": true
+        }
+      },
+      {
+        "name": "advanced",
+        "options": {
+          "description": "extract inputs",
+          "xml": "\u003cassign:extract-value\u003e\n   \u003cvariable-name\u003eENDUSER\u003c/variable-name\u003e\n   \u003clocation\u003eQuery_String\u003c/location\u003e\n   \u003clocation-id\u003eenduser\u003c/location-id\u003e\n   \u003cseparator\u003e=\u003c/separator\u003e\n\u003c/assign:extract-value\u003e\n\u003cassign:extract-value\u003e\n   \u003cvariable-name\u003eGHOST\u003c/variable-name\u003e\n   \u003clocation\u003eQuery_String\u003c/location\u003e\n   \u003clocation-id\u003eghost\u003c/location-id\u003e\n   \u003cseparator\u003e=\u003c/separator\u003e\n\u003c/assign:extract-value\u003e\n\n\u003cassign:variable\u003e\n   \u003cname\u003eDISTANCE\u003c/name\u003e\n   \u003ctransform\u003e\n      \u003cgeo-distance\u003e\n         \u003cip1\u003e%(ENDUSER)\u003c/ip1\u003e\n         \u003cip2\u003e%(GHOST)\u003c/ip2\u003e\n      \u003c/geo-distance\u003e\n   \u003c/transform\u003e\n\u003c/assign:variable\u003e\n\n\n\n\u003cedgeservices:construct-response\u003e\n   \u003cstatus\u003eon\u003c/status\u003e\n   \u003chttp-status\u003e200\u003c/http-status\u003e\n   \u003cbody\u003e%(DISTANCE)\u003c/body\u003e\n   \u003cforce-cache-eviction\u003eoff\u003c/force-cache-eviction\u003e\n\u003c/edgeservices:construct-response\u003e\n\n\u003cedgeservices:modify-outgoing-response.add-header\u003e\n      \u003cname\u003eDistance\u003c/name\u003e\n      \u003cvalue\u003e%(DISTANCE)\u003c/value\u003e\n   \u003c/edgeservices:modify-outgoing-response.add-header\u003e"
+        },
+        "uuid": "feeaeff9-fe7e-4e27-ba0c-7b1dcecdba8b"
+      }
+    ],
+    "children": [
+      {
+        "behaviors": [
+          {
+            "name": "gzipResponse",
+            "options": {
+              "behavior": "ALWAYS"
+            }
+          }
+        ],
+        "criteria": [
+          {
+            "name": "contentType",
+            "options": {
+              "matchCaseSensitive": false,
+              "matchOperator": "IS_ONE_OF",
+              "matchWildcard": true,
+              "values": [
+                "text/html*",
+                "text/css*",
+                "application/x-javascript*"
+              ]
+            }
+          }
+        ],
+        "name": "Content Compression",
+        "options": {},
+        "criteriaMustSatisfy": "all"
+      },
+      {
+        "behaviors": [
+          {
+            "name": "caching",
+            "options": {
+              "behavior": "MAX_AGE",
+              "mustRevalidate": false,
+              "ttl": "1d"
+            }
+          }
+        ],
+        "criteria": [
+          {
+            "name": "fileExtension",
+            "options": {
+              "matchCaseSensitive": false,
+              "matchOperator": "IS_ONE_OF",
+              "values": [
+                "aif",
+                "aiff",
+                "au",
+                "avi",
+                "bin",
+                "bmp",
+                "cab",
+                "carb",
+                "cct",
+                "cdf",
+                "class",
+                "css",
+                "doc",
+                "dcr",
+                "dtd",
+                "exe",
+                "flv",
+                "gcf",
+                "gff",
+                "gif",
+                "grv",
+                "hdml",
+                "hqx",
+                "ico",
+                "ini",
+                "jpeg",
+                "jpg",
+                "js",
+                "mov",
+                "mp3",
+                "nc",
+                "pct",
+                "pdf",
+                "png",
+                "ppc",
+                "pws",
+                "swa",
+                "swf",
+                "txt",
+                "vbs",
+                "w32",
+                "wav",
+                "wbmp",
+                "wml",
+                "wmlc",
+                "wmls",
+                "wmlsc",
+                "xsd",
+                "zip",
+                "webp",
+                "jxr",
+                "hdp",
+                "wdp",
+                "pict",
+                "tif",
+                "tiff",
+                "mid",
+                "midi",
+                "ttf",
+                "eot",
+                "woff",
+                "otf",
+                "svg",
+                "svgz",
+                "jar",
+                "woff2"
+              ]
+            }
+          }
+        ],
+        "name": "Static Content",
+        "options": {},
+        "criteriaMustSatisfy": "all"
+      },
+      {
+        "behaviors": [
+          {
+            "name": "downstreamCache",
+            "options": {
+              "behavior": "TUNNEL_ORIGIN"
+            }
+          }
+        ],
+        "criteria": [
+          {
+            "name": "cacheability",
+            "options": {
+              "matchOperator": "IS_NOT",
+              "value": "CACHEABLE"
+            }
+          }
+        ],
+        "name": "Dynamic Content",
+        "options": {},
+        "criteriaMustSatisfy": "all"
+      }
+    ],
+    "name": "default",
+    "options": {},
+    "uuid": "default"
+  }
+}

--- a/pkg/providers/papi/testdata/basic_property_with_multiple_includes_schema/mock_second_include_rules.json
+++ b/pkg/providers/papi/testdata/basic_property_with_multiple_includes_schema/mock_second_include_rules.json
@@ -1,0 +1,223 @@
+{
+  "accountId": "test_account",
+  "contractId": "test_contract",
+  "groupId": "test_group",
+  "includeId": "inc_78910",
+  "includeVersion": 2,
+  "includeType": "MICROSERVICES",
+  "etag": "4607f363da8bc05b0c0f0f7524985d2fbc5d864d",
+  "ruleFormat": "v2023-01-05",
+  "rules": {
+    "behaviors": [
+      {
+        "name": "origin",
+        "options": {
+          "cacheKeyHostname": "ORIGIN_HOSTNAME",
+          "compress": true,
+          "enableTrueClientIp": false,
+          "forwardHostHeader": "REQUEST_HOST_HEADER",
+          "hostname": "1.2.3.4",
+          "httpPort": 80,
+          "httpsPort": 443,
+          "originSni": false,
+          "originType": "CUSTOMER",
+          "useUniqueCacheKey": false,
+          "verificationMode": "PLATFORM_SETTINGS"
+        }
+      },
+      {
+        "name": "cpCode",
+        "options": {
+          "value": {
+            "createdDate": 1506429558000,
+            "description": "Test-NewHire",
+            "id": 626358,
+            "name": "Test-NewHire",
+            "products": [
+              "Site_Defender"
+            ]
+          }
+        }
+      },
+      {
+        "name": "caching",
+        "options": {
+          "behavior": "NO_STORE"
+        }
+      },
+      {
+        "name": "allowPost",
+        "options": {
+          "allowWithoutContentLength": false,
+          "enabled": true
+        }
+      },
+      {
+        "name": "report",
+        "options": {
+          "logAcceptLanguage": false,
+          "logCookies": "OFF",
+          "logCustomLogField": false,
+          "logHost": false,
+          "logReferer": false,
+          "logUserAgent": true
+        }
+      },
+      {
+        "name": "advanced",
+        "options": {
+          "description": "extract inputs",
+          "xml": "\u003cassign:extract-value\u003e\n   \u003cvariable-name\u003eENDUSER\u003c/variable-name\u003e\n   \u003clocation\u003eQuery_String\u003c/location\u003e\n   \u003clocation-id\u003eenduser\u003c/location-id\u003e\n   \u003cseparator\u003e=\u003c/separator\u003e\n\u003c/assign:extract-value\u003e\n\u003cassign:extract-value\u003e\n   \u003cvariable-name\u003eGHOST\u003c/variable-name\u003e\n   \u003clocation\u003eQuery_String\u003c/location\u003e\n   \u003clocation-id\u003eghost\u003c/location-id\u003e\n   \u003cseparator\u003e=\u003c/separator\u003e\n\u003c/assign:extract-value\u003e\n\n\u003cassign:variable\u003e\n   \u003cname\u003eDISTANCE\u003c/name\u003e\n   \u003ctransform\u003e\n      \u003cgeo-distance\u003e\n         \u003cip1\u003e%(ENDUSER)\u003c/ip1\u003e\n         \u003cip2\u003e%(GHOST)\u003c/ip2\u003e\n      \u003c/geo-distance\u003e\n   \u003c/transform\u003e\n\u003c/assign:variable\u003e\n\n\n\n\u003cedgeservices:construct-response\u003e\n   \u003cstatus\u003eon\u003c/status\u003e\n   \u003chttp-status\u003e200\u003c/http-status\u003e\n   \u003cbody\u003e%(DISTANCE)\u003c/body\u003e\n   \u003cforce-cache-eviction\u003eoff\u003c/force-cache-eviction\u003e\n\u003c/edgeservices:construct-response\u003e\n\n\u003cedgeservices:modify-outgoing-response.add-header\u003e\n      \u003cname\u003eDistance\u003c/name\u003e\n      \u003cvalue\u003e%(DISTANCE)\u003c/value\u003e\n   \u003c/edgeservices:modify-outgoing-response.add-header\u003e"
+        },
+        "uuid": "feeaeff9-fe7e-4e27-ba0c-7b1dcecdba8b"
+      }
+    ],
+    "children": [
+      {
+        "behaviors": [
+          {
+            "name": "gzipResponse",
+            "options": {
+              "behavior": "ALWAYS"
+            }
+          }
+        ],
+        "criteria": [
+          {
+            "name": "contentType",
+            "options": {
+              "matchCaseSensitive": false,
+              "matchOperator": "IS_ONE_OF",
+              "matchWildcard": true,
+              "values": [
+                "text/html*",
+                "text/css*",
+                "application/x-javascript*"
+              ]
+            }
+          }
+        ],
+        "name": "Content Compression",
+        "options": {},
+        "criteriaMustSatisfy": "all"
+      },
+      {
+        "behaviors": [
+          {
+            "name": "caching",
+            "options": {
+              "behavior": "MAX_AGE",
+              "mustRevalidate": false,
+              "ttl": "1d"
+            }
+          }
+        ],
+        "criteria": [
+          {
+            "name": "fileExtension",
+            "options": {
+              "matchCaseSensitive": false,
+              "matchOperator": "IS_ONE_OF",
+              "values": [
+                "aif",
+                "aiff",
+                "au",
+                "avi",
+                "bin",
+                "bmp",
+                "cab",
+                "carb",
+                "cct",
+                "cdf",
+                "class",
+                "css",
+                "doc",
+                "dcr",
+                "dtd",
+                "exe",
+                "flv",
+                "gcf",
+                "gff",
+                "gif",
+                "grv",
+                "hdml",
+                "hqx",
+                "ico",
+                "ini",
+                "jpeg",
+                "jpg",
+                "js",
+                "mov",
+                "mp3",
+                "nc",
+                "pct",
+                "pdf",
+                "png",
+                "ppc",
+                "pws",
+                "swa",
+                "swf",
+                "txt",
+                "vbs",
+                "w32",
+                "wav",
+                "wbmp",
+                "wml",
+                "wmlc",
+                "wmls",
+                "wmlsc",
+                "xsd",
+                "zip",
+                "webp",
+                "jxr",
+                "hdp",
+                "wdp",
+                "pict",
+                "tif",
+                "tiff",
+                "mid",
+                "midi",
+                "ttf",
+                "eot",
+                "woff",
+                "otf",
+                "svg",
+                "svgz",
+                "jar",
+                "woff2"
+              ]
+            }
+          }
+        ],
+        "name": "Static Content",
+        "options": {},
+        "criteriaMustSatisfy": "all"
+      },
+      {
+        "behaviors": [
+          {
+            "name": "downstreamCache",
+            "options": {
+              "behavior": "TUNNEL_ORIGIN"
+            }
+          }
+        ],
+        "criteria": [
+          {
+            "name": "cacheability",
+            "options": {
+              "matchOperator": "IS_NOT",
+              "value": "CACHEABLE"
+            }
+          }
+        ],
+        "name": "Dynamic Content",
+        "options": {},
+        "criteriaMustSatisfy": "all"
+      }
+    ],
+    "name": "default",
+    "options": {},
+    "uuid": "default"
+  }
+}

--- a/pkg/providers/papi/testdata/basic_property_with_multiple_includes_schema/property.tf
+++ b/pkg/providers/papi/testdata/basic_property_with_multiple_includes_schema/property.tf
@@ -1,0 +1,51 @@
+terraform {
+  required_providers {
+    akamai = {
+      source  = "akamai/akamai"
+      version = ">= 3.5.0"
+    }
+  }
+  required_version = ">= 0.13"
+}
+
+provider "akamai" {
+  edgerc         = var.edgerc_path
+  config_section = var.config_section
+}
+
+data "akamai_group" "group" {
+  group_name  = "test_group"
+  contract_id = "test_contract"
+}
+
+data "akamai_contract" "contract" {
+  group_name = data.akamai_group.group.group_name
+}
+
+resource "akamai_edge_hostname" "test-edgesuite-net" {
+  contract_id   = data.akamai_contract.contract.id
+  group_id      = data.akamai_group.group.id
+  ip_behavior   = "IPV6_COMPLIANCE"
+  edge_hostname = "test.edgesuite.net"
+}
+
+resource "akamai_property" "test-edgesuite-net" {
+  name        = "test.edgesuite.net"
+  contract_id = data.akamai_contract.contract.id
+  group_id    = data.akamai_group.group.id
+  product_id  = "prd_HTTP_Content_Del"
+  hostnames {
+    cname_from             = "test.edgesuite.net"
+    cname_to               = akamai_edge_hostname.test-edgesuite-net.edge_hostname
+    cert_provisioning_type = "CPS_MANAGED"
+  }
+  rule_format = data.akamai_property_rules_builder.test-edgesuite-net_rule_default.rule_format
+  rules       = data.akamai_property_rules_builder.test-edgesuite-net_rule_default.json
+}
+
+resource "akamai_property_activation" "test-edgesuite-net" {
+  property_id = akamai_property.test-edgesuite-net.id
+  contact     = ["jsmith@akamai.com"]
+  version     = akamai_property.test-edgesuite-net.latest_version
+  network     = upper(var.env)
+}

--- a/pkg/providers/papi/testdata/basic_property_with_multiple_includes_schema/variables.tf
+++ b/pkg/providers/papi/testdata/basic_property_with_multiple_includes_schema/variables.tf
@@ -1,0 +1,14 @@
+variable "edgerc_path" {
+  type    = string
+  default = "~/.edgerc"
+}
+
+variable "config_section" {
+  type    = string
+  default = "test_section"
+}
+
+variable "env" {
+  type    = string
+  default = "staging"
+}

--- a/pkg/providers/papi/testdata/include_basic_schema/import.sh
+++ b/pkg/providers/papi/testdata/include_basic_schema/import.sh
@@ -1,0 +1,4 @@
+terraform init
+terraform import akamai_property_include.test_include test_contract:test_group:inc_123456
+terraform import akamai_property_include_activation.test_include_staging test_contract:test_group:inc_123456:STAGING
+terraform import akamai_property_include_activation.test_include_production test_contract:test_group:inc_123456:PRODUCTION

--- a/pkg/providers/papi/testdata/include_basic_schema/includes.tf
+++ b/pkg/providers/papi/testdata/include_basic_schema/includes.tf
@@ -14,9 +14,6 @@ provider "akamai" {
 }
 
 
-data "akamai_property_rules_template" "rules_test_include" {
-  template_file = abspath("${path.module}/property-snippets/test_include.json")
-}
 
 /*
 data "akamai_property_include_parents" "test_include" {
@@ -31,8 +28,8 @@ resource "akamai_property_include" "test_include" {
   group_id    = "test_group"
   name        = "test_include"
   type        = "MICROSERVICES"
-  rule_format = "v2020-11-02"
-  rules       = data.akamai_property_rules_template.rules_test_include.json
+  rule_format = data.akamai_property_rules_builder.test_include_rule_default.rule_format
+  rules       = data.akamai_property_rules_builder.test_include_rule_default.json
 }
 
 resource "akamai_property_include_activation" "test_include_staging" {

--- a/pkg/providers/papi/testdata/include_basic_schema/includes_rules.tf
+++ b/pkg/providers/papi/testdata/include_basic_schema/includes_rules.tf
@@ -1,0 +1,125 @@
+
+data "akamai_property_rules_builder" "test_include_rule_default" {
+  rules_v2023_01_05 {
+    name      = "default"
+    is_secure = false
+    uuid      = "default"
+    behavior {
+      origin {
+        cache_key_hostname    = "ORIGIN_HOSTNAME"
+        compress              = true
+        enable_true_client_ip = false
+        forward_host_header   = "REQUEST_HOST_HEADER"
+        hostname              = "1.2.3.4"
+        http_port             = 80
+        https_port            = 443
+        origin_sni            = false
+        origin_type           = "CUSTOMER"
+        use_unique_cache_key  = false
+        verification_mode     = "PLATFORM_SETTINGS"
+      }
+    }
+    behavior {
+      cp_code {
+        value {
+          created_date = 1506429558000
+          description  = "Test-NewHire"
+          id           = 626358
+          name         = "Test-NewHire"
+          products     = ["Site_Defender", ]
+        }
+      }
+    }
+    behavior {
+      caching {
+        behavior = "NO_STORE"
+      }
+    }
+    behavior {
+      allow_post {
+        allow_without_content_length = false
+        enabled                      = true
+      }
+    }
+    behavior {
+      report {
+        log_accept_language  = false
+        log_cookies          = "OFF"
+        log_custom_log_field = false
+        log_host             = false
+        log_referer          = false
+        log_user_agent       = true
+      }
+    }
+    behavior {
+      advanced {
+        uuid        = "feeaeff9-fe7e-4e27-ba0c-7b1dcecdba8b"
+        description = "extract inputs"
+      }
+    }
+    children = [
+      data.akamai_property_rules_builder.test_include_rule_content_compression.json,
+      data.akamai_property_rules_builder.test_include_rule_static_content.json,
+      data.akamai_property_rules_builder.test_include_rule_dynamic_content.json,
+    ]
+  }
+}
+
+data "akamai_property_rules_builder" "test_include_rule_content_compression" {
+  rules_v2023_01_05 {
+    name                  = "Content Compression"
+    criteria_must_satisfy = "all"
+    criterion {
+      content_type {
+        match_case_sensitive = false
+        match_operator       = "IS_ONE_OF"
+        match_wildcard       = true
+        values               = ["text/html*", "text/css*", "application/x-javascript*", ]
+      }
+    }
+    behavior {
+      gzip_response {
+        behavior = "ALWAYS"
+      }
+    }
+  }
+}
+
+data "akamai_property_rules_builder" "test_include_rule_static_content" {
+  rules_v2023_01_05 {
+    name                  = "Static Content"
+    criteria_must_satisfy = "all"
+    criterion {
+      file_extension {
+        match_case_sensitive = false
+        match_operator       = "IS_ONE_OF"
+        values               = ["aif", "aiff", "au", "avi", "bin", "bmp", "cab", "carb", "cct", "cdf", "class", "css", "doc", "dcr", "dtd", "exe", "flv", "gcf", "gff", "gif", "grv", "hdml", "hqx", "ico", "ini", "jpeg", "jpg", "js", "mov", "mp3", "nc", "pct", "pdf", "png", "ppc", "pws", "swa", "swf", "txt", "vbs", "w32", "wav", "wbmp", "wml", "wmlc", "wmls", "wmlsc", "xsd", "zip", "webp", "jxr", "hdp", "wdp", "pict", "tif", "tiff", "mid", "midi", "ttf", "eot", "woff", "otf", "svg", "svgz", "jar", "woff2", ]
+      }
+    }
+    behavior {
+      caching {
+        behavior        = "MAX_AGE"
+        must_revalidate = false
+        ttl             = "1d"
+      }
+    }
+  }
+}
+
+data "akamai_property_rules_builder" "test_include_rule_dynamic_content" {
+  rules_v2023_01_05 {
+    name                  = "Dynamic Content"
+    criteria_must_satisfy = "all"
+    criterion {
+      cacheability {
+        match_operator = "IS_NOT"
+        value          = "CACHEABLE"
+      }
+    }
+    behavior {
+      downstream_cache {
+        behavior = "TUNNEL_ORIGIN"
+      }
+    }
+  }
+}

--- a/pkg/providers/papi/testdata/include_basic_schema/mock_rules.json
+++ b/pkg/providers/papi/testdata/include_basic_schema/mock_rules.json
@@ -1,0 +1,222 @@
+{
+  "accountId": "test_account",
+  "contractId": "test_contract",
+  "groupId": "test_group",
+  "includeId": "inc_123456",
+  "includeVersion": 2,
+  "includeType": "MICROSERVICES",
+  "etag": "4607f363da8bc05b0c0f0f7524985d2fbc5d864d",
+  "ruleFormat": "v2023-01-05",
+  "rules": {
+    "behaviors": [
+      {
+        "name": "origin",
+        "options": {
+          "cacheKeyHostname": "ORIGIN_HOSTNAME",
+          "compress": true,
+          "enableTrueClientIp": false,
+          "forwardHostHeader": "REQUEST_HOST_HEADER",
+          "hostname": "1.2.3.4",
+          "httpPort": 80,
+          "httpsPort": 443,
+          "originSni": false,
+          "originType": "CUSTOMER",
+          "useUniqueCacheKey": false,
+          "verificationMode": "PLATFORM_SETTINGS"
+        }
+      },
+      {
+        "name": "cpCode",
+        "options": {
+          "value": {
+            "createdDate": 1506429558000,
+            "description": "Test-NewHire",
+            "id": 626358,
+            "name": "Test-NewHire",
+            "products": [
+              "Site_Defender"
+            ]
+          }
+        }
+      },
+      {
+        "name": "caching",
+        "options": {
+          "behavior": "NO_STORE"
+        }
+      },
+      {
+        "name": "allowPost",
+        "options": {
+          "allowWithoutContentLength": false,
+          "enabled": true
+        }
+      },
+      {
+        "name": "report",
+        "options": {
+          "logAcceptLanguage": false,
+          "logCookies": "OFF",
+          "logCustomLogField": false,
+          "logHost": false,
+          "logReferer": false,
+          "logUserAgent": true
+        }
+      },
+      {
+        "name": "advanced",
+        "options": {
+          "description": "extract inputs"
+        },
+        "uuid": "feeaeff9-fe7e-4e27-ba0c-7b1dcecdba8b"
+      }
+    ],
+    "children": [
+      {
+        "behaviors": [
+          {
+            "name": "gzipResponse",
+            "options": {
+              "behavior": "ALWAYS"
+            }
+          }
+        ],
+        "criteria": [
+          {
+            "name": "contentType",
+            "options": {
+              "matchCaseSensitive": false,
+              "matchOperator": "IS_ONE_OF",
+              "matchWildcard": true,
+              "values": [
+                "text/html*",
+                "text/css*",
+                "application/x-javascript*"
+              ]
+            }
+          }
+        ],
+        "name": "Content Compression",
+        "options": {},
+        "criteriaMustSatisfy": "all"
+      },
+      {
+        "behaviors": [
+          {
+            "name": "caching",
+            "options": {
+              "behavior": "MAX_AGE",
+              "mustRevalidate": false,
+              "ttl": "1d"
+            }
+          }
+        ],
+        "criteria": [
+          {
+            "name": "fileExtension",
+            "options": {
+              "matchCaseSensitive": false,
+              "matchOperator": "IS_ONE_OF",
+              "values": [
+                "aif",
+                "aiff",
+                "au",
+                "avi",
+                "bin",
+                "bmp",
+                "cab",
+                "carb",
+                "cct",
+                "cdf",
+                "class",
+                "css",
+                "doc",
+                "dcr",
+                "dtd",
+                "exe",
+                "flv",
+                "gcf",
+                "gff",
+                "gif",
+                "grv",
+                "hdml",
+                "hqx",
+                "ico",
+                "ini",
+                "jpeg",
+                "jpg",
+                "js",
+                "mov",
+                "mp3",
+                "nc",
+                "pct",
+                "pdf",
+                "png",
+                "ppc",
+                "pws",
+                "swa",
+                "swf",
+                "txt",
+                "vbs",
+                "w32",
+                "wav",
+                "wbmp",
+                "wml",
+                "wmlc",
+                "wmls",
+                "wmlsc",
+                "xsd",
+                "zip",
+                "webp",
+                "jxr",
+                "hdp",
+                "wdp",
+                "pict",
+                "tif",
+                "tiff",
+                "mid",
+                "midi",
+                "ttf",
+                "eot",
+                "woff",
+                "otf",
+                "svg",
+                "svgz",
+                "jar",
+                "woff2"
+              ]
+            }
+          }
+        ],
+        "name": "Static Content",
+        "options": {},
+        "criteriaMustSatisfy": "all"
+      },
+      {
+        "behaviors": [
+          {
+            "name": "downstreamCache",
+            "options": {
+              "behavior": "TUNNEL_ORIGIN"
+            }
+          }
+        ],
+        "criteria": [
+          {
+            "name": "cacheability",
+            "options": {
+              "matchOperator": "IS_NOT",
+              "value": "CACHEABLE"
+            }
+          }
+        ],
+        "name": "Dynamic Content",
+        "options": {},
+        "criteriaMustSatisfy": "all"
+      }
+    ],
+    "name": "default",
+    "options": {},
+    "uuid": "default"
+  }
+}

--- a/pkg/providers/papi/testdata/include_basic_schema/variables.tf
+++ b/pkg/providers/papi/testdata/include_basic_schema/variables.tf
@@ -1,0 +1,14 @@
+variable "edgerc_path" {
+  type    = string
+  default = "~/.edgerc"
+}
+
+variable "config_section" {
+  type    = string
+  default = "test_section"
+}
+
+#variable "env" {
+#  type    = string
+#  default = "staging"
+#}

--- a/pkg/providers/papi/testdata/include_no_network/includes.tf
+++ b/pkg/providers/papi/testdata/include_no_network/includes.tf
@@ -19,7 +19,7 @@ data "akamai_property_rules_template" "rules_test_include" {
 }
 
 /*
-data "akamai_property_include_parents" "include_parents" {
+data "akamai_property_include_parents" "test_include" {
   contract_id = "test_contract"
   group_id    = "test_group"
   include_id  = "inc_123456"
@@ -30,7 +30,7 @@ resource "akamai_property_include" "test_include" {
   contract_id = "test_contract"
   group_id    = "test_group"
   name        = "test_include"
-  rule_format = "v2020-11-02"
   type        = "MICROSERVICES"
+  rule_format = "v2020-11-02"
   rules       = data.akamai_property_rules_template.rules_test_include.json
 }

--- a/pkg/providers/papi/testdata/include_single_network/includes.tf
+++ b/pkg/providers/papi/testdata/include_single_network/includes.tf
@@ -19,7 +19,7 @@ data "akamai_property_rules_template" "rules_test_include" {
 }
 
 /*
-data "akamai_property_include_parents" "include_parents" {
+data "akamai_property_include_parents" "test_include" {
   contract_id = "test_contract"
   group_id    = "test_group"
   include_id  = "inc_123456"
@@ -30,8 +30,8 @@ resource "akamai_property_include" "test_include" {
   contract_id = "test_contract"
   group_id    = "test_group"
   name        = "test_include"
-  rule_format = "v2020-11-02"
   type        = "MICROSERVICES"
+  rule_format = "v2020-11-02"
   rules       = data.akamai_property_rules_template.rules_test_include.json
 }
 


### PR DESCRIPTION
## Version 1.6.0 (May 31, 2023)

### Bug fixes

* Fix escaping of `akamai_gtm_property` `static_rr_set.rdata` field
* Export of some fields depends on the fact if the rule is default or not

### Features/Enhancements

* Migrate to Terraform 1.3.7 version
* Flag `schema` works now with `include` sub-command as well with `with-includes` flag
