### PR TITLE
Release/v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Features/Enhancements
 
-* CloudWrapper
+* [IMPORTANT] CloudWrapper
   * Added support for `export-cloudwrapper` command which allows export of `akamai_cloudwrapper_configuration` and `akamai_cloudwrapper_activation` resources
 
 * APPSEC
-  * Add import support for custom client sequence
+  * Added import support for custom client sequence
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Release Notes
 
-## Version 1.x.x (xxxx yy, 2023)
+## Version 1.9.0 (August 29, 2023)
+
+### Features/Enhancements
+
+* CloudWrapper
+  * Added support for `export-cloudwrapper` command which allows export of `akamai_cloudwrapper_configuration` and `akamai_cloudwrapper_activation` resources
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * PAPI
   * Fixed `export-property` command to export `akamai_property_activation` resource attributes for latest active version.
+  * Fixed `export-property` command to use `group_id` and `contract_id` as terraform variables, instead of data sources, which
+  produced inconsistencies ([I#374](https://github.com/akamai/terraform-provider-akamai/issues/426))
 
 ## Version 1.8.0 (August 1, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Release Notes
+## Version 1.x.x (xxxx yy, 2023)
+
+### Bug fixes
+
+* PAPI
+  * Fixed `export-property` command to export `akamai_property_activation` resource attributes for latest active version.
 
 ## Version 1.8.0 (August 1, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ### Bug fixes
 
+* Image and Video Manager
+  * Added description for `--schema` flag for `export-imaging` command in `README.md` ([#56](https://github.com/akamai/cli-terraform/issues/56))
+
 * PAPI
   * Fixed `export-property` command to export `akamai_property_activation` resource attributes for latest active version.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Release Notes
+
 ## Version 1.x.x (xxxx yy, 2023)
 
 ### Bug fixes
@@ -10,6 +11,8 @@
   * Fixed `export-property` command to export `akamai_property_activation` resource attributes for latest active version.
   * Fixed `export-property` command to use `group_id` and `contract_id` as terraform variables, instead of data sources, which
   produced inconsistencies ([I#374](https://github.com/akamai/terraform-provider-akamai/issues/426))
+  * `logStreamName` field from `datastream` behavior has changed from string to array of strings for rule
+    format `v2023-05-30` ([#58](https://github.com/akamai/cli-terraform/issues/58))
 
 ## Version 1.8.0 (August 1, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * CloudWrapper
   * Added support for `export-cloudwrapper` command which allows export of `akamai_cloudwrapper_configuration` and `akamai_cloudwrapper_activation` resources
 
+* APPSEC
+  * Add import support for custom client sequence
+
 ### Bug fixes
 
 * Image and Video Manager

--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ $ akamai terraform export-iam
 Flags:
    --tfworkpath path         Directory used to store files created when running commands. (default: current directory)
    --policy-json-dir path    Path location for placement of policy jsons. Default: same value as tfworkpath
+   --schema                  Generate content of the policy using HCL instead of JSON file (default: false)
 ```
 
 ### Export Image and Video policy configuration.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Description:
    Administer and manage available Akamai resources with Terraform
 
 Built-In Commands:
+  export-cloudwrapper
   export-domain (alias: create-domain)
   export-zone (alias: create-zone)
   export-appsec (alias: create-appsec)
@@ -224,6 +225,23 @@ Flags:
 
 ```
 $ akamai terraform export-cloudlets-policy
+```
+
+## CloudWrapper
+
+### Usage
+
+```
+   akamai terraform [global flags] export-cloudwrapper [flags] <configuration_id>
+
+Flags:
+   --tfworkpath path      Directory used to store files created when running commands. (default: current directory)
+```
+
+### Export CloudWrapper configuration.
+
+```
+$ akamai terraform export-cloudwrapper
 ```
 
 ## EdgeWorkers

--- a/cli.json
+++ b/cli.json
@@ -5,7 +5,7 @@
   "commands": [
     {
       "name": "terraform",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "description": "Administer and Manage Akamai Terraform configurations",
       "bin": "https://github.com/akamai/cli-terraform/releases/download/v{{.Version}}/akamai-{{.Name}}-{{.Version}}-{{.OS}}{{.Arch}}{{.BinSuffix}}",
       "auto-complete": true,

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -33,7 +33,7 @@ import (
 
 var (
 	// Version holds current version of cli-terraform
-	Version = "1.8.0"
+	Version = "1.9.0"
 )
 
 // Run initializes the cli and runs it

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/akamai/cli-terraform
 go 1.18
 
 require (
-	github.com/akamai/AkamaiOPEN-edgegrid-golang/v7 v7.2.0
+	github.com/akamai/AkamaiOPEN-edgegrid-golang/v7 v7.2.1
 	github.com/akamai/cli v1.5.5
 	github.com/fatih/color v1.13.0
 	github.com/hashicorp/hcl/v2 v2.11.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/akamai/cli-terraform
 go 1.18
 
 require (
-	github.com/akamai/AkamaiOPEN-edgegrid-golang/v7 v7.1.0
+	github.com/akamai/AkamaiOPEN-edgegrid-golang/v7 v7.2.0
 	github.com/akamai/cli v1.5.5
 	github.com/fatih/color v1.13.0
 	github.com/hashicorp/hcl/v2 v2.11.1

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDO
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/akamai/AkamaiOPEN-edgegrid-golang/v7 v7.2.0 h1:sGkT91nSXjHU/s+ItP+kTgea1WCfpgAWwx+snxlP/+E=
-github.com/akamai/AkamaiOPEN-edgegrid-golang/v7 v7.2.0/go.mod h1:zZWAMUwE4q5sVPgnjz9jiqtXA01tM3m9HYd6Wk0ev90=
+github.com/akamai/AkamaiOPEN-edgegrid-golang/v7 v7.2.1 h1:amPKOiXDgUXQcSMMg0XXvOZkF9sQcffZXZrZT4VJ3z0=
+github.com/akamai/AkamaiOPEN-edgegrid-golang/v7 v7.2.1/go.mod h1:zZWAMUwE4q5sVPgnjz9jiqtXA01tM3m9HYd6Wk0ev90=
 github.com/akamai/cli v1.5.5 h1:XKubVW8WOVP8qcgJRK2MOj8HeqC4kudvSOM0m8mJsj0=
 github.com/akamai/cli v1.5.5/go.mod h1:29wClp63PEEkpDLxtqM/JrVmnwOCSaE+itIJjCAIECE=
 github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 h1:MzBOUgng9orim59UnfUTLRjMpd09C5uEVQ6RPGeCaVI=

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDO
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/akamai/AkamaiOPEN-edgegrid-golang/v7 v7.1.0 h1:QBcW0BOSLBN2DGgs6je3L/E/S3nCKhi4Me4oijT44Dw=
-github.com/akamai/AkamaiOPEN-edgegrid-golang/v7 v7.1.0/go.mod h1:zZWAMUwE4q5sVPgnjz9jiqtXA01tM3m9HYd6Wk0ev90=
+github.com/akamai/AkamaiOPEN-edgegrid-golang/v7 v7.2.0 h1:sGkT91nSXjHU/s+ItP+kTgea1WCfpgAWwx+snxlP/+E=
+github.com/akamai/AkamaiOPEN-edgegrid-golang/v7 v7.2.0/go.mod h1:zZWAMUwE4q5sVPgnjz9jiqtXA01tM3m9HYd6Wk0ev90=
 github.com/akamai/cli v1.5.5 h1:XKubVW8WOVP8qcgJRK2MOj8HeqC4kudvSOM0m8mJsj0=
 github.com/akamai/cli v1.5.5/go.mod h1:29wClp63PEEkpDLxtqM/JrVmnwOCSaE+itIJjCAIECE=
 github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 h1:MzBOUgng9orim59UnfUTLRjMpd09C5uEVQ6RPGeCaVI=

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -18,6 +18,7 @@ package commands
 import (
 	"github.com/akamai/cli-terraform/pkg/providers/appsec"
 	"github.com/akamai/cli-terraform/pkg/providers/cloudlets"
+	"github.com/akamai/cli-terraform/pkg/providers/cloudwrapper"
 	"github.com/akamai/cli-terraform/pkg/providers/cps"
 	"github.com/akamai/cli-terraform/pkg/providers/dns"
 	"github.com/akamai/cli-terraform/pkg/providers/edgeworkers"
@@ -147,6 +148,22 @@ func CommandLocator() ([]*cli.Command, error) {
 			&cli.BoolFlag{
 				Name:  "schema",
 				Usage: "Referenced rules will be exported as data source",
+			},
+		},
+		BashComplete: autocomplete.Default,
+	})
+
+	commands = append(commands, &cli.Command{
+		Name:        "export-cloudwrapper",
+		Description: "Generates Terraform configuration for CloudWrapper resources",
+		Usage:       "export-cloudwrapper",
+		ArgsUsage:   "<config_id>",
+		Action:      validatedAction(cloudwrapper.CmdCreateCloudWrapper, requireValidWorkpath, requireNArguments(1)),
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:        "tfworkpath",
+				Usage:       "Directory used to store files created when running commands.",
+				DefaultText: "current directory",
 			},
 		},
 		BashComplete: autocomplete.Default,

--- a/pkg/providers/appsec/create_appsec.go
+++ b/pkg/providers/appsec/create_appsec.go
@@ -137,6 +137,7 @@ func CmdCreateAppsec(c *cli.Context) error {
 		"exportJSONWithoutKeys":                  exportJSONWithoutKeys,
 		"getCustomBotCategoryResourceNamesByIDs": getCustomBotCategoryResourceNamesByIDs,
 		"getCustomBotCategoryNameByID":           getCustomBotCategoryNameByID,
+		"getCustomClientResourceNamesByIDs":      getCustomClientResourceNamesByIDs,
 	}
 
 	// The template processor
@@ -560,4 +561,33 @@ func getCustomBotCategoryResourceNamesByIDs(customBotCategories []map[string]int
 		categoryResourceNames[i] = fmt.Sprintf("akamai_botman_custom_bot_category.%s_%s.category_id", categoryName, categoryID)
 	}
 	return strings.Join(categoryResourceNames, ","), nil
+}
+
+// getCustomClientResourceNamesByIDs returns comma separated custom-client resource names in the same order as the provided customClientIDs
+func getCustomClientResourceNamesByIDs(customClients []map[string]interface{}, customClientIDs []string) (string, error) {
+	customClientMap := make(map[string]string)
+	for _, customClient := range customClients {
+		customClientName, ok := customClient["customClientName"].(string)
+		if !ok {
+			return "", fmt.Errorf("cannot convert custom client name %s to string", customClient["customClientName"])
+		}
+		name, err := tools.EscapeName(customClientName)
+		if err != nil {
+			return "", err
+		}
+		customClientID, ok := customClient["customClientId"].(string)
+		if !ok {
+			return "", errors.New("cannot convert customClientId to string")
+		}
+		customClientMap[customClientID] = name
+	}
+	customClientResourceNames := make([]string, len(customClientIDs))
+	for i, customClientID := range customClientIDs {
+		customClientName, ok := customClientMap[customClientID]
+		if !ok {
+			return "", fmt.Errorf("cannot find custom client name for id %s", customClientID)
+		}
+		customClientResourceNames[i] = fmt.Sprintf("akamai_botman_custom_client.%s_%s.custom_client_id", customClientName, customClientID)
+	}
+	return strings.Join(customClientResourceNames, ",\n"), nil
 }

--- a/pkg/providers/appsec/create_appsec_test.go
+++ b/pkg/providers/appsec/create_appsec_test.go
@@ -300,6 +300,7 @@ func TestProcessPolicyTemplates(t *testing.T) {
 		"exportJSONWithoutKeys":                  exportJSONWithoutKeys,
 		"getCustomBotCategoryNameByID":           getCustomBotCategoryNameByID,
 		"getCustomBotCategoryResourceNamesByIDs": getCustomBotCategoryResourceNamesByIDs,
+		"getCustomClientResourceNamesByIDs":      getCustomClientResourceNamesByIDs,
 	}
 
 	// Template to path mappings
@@ -421,6 +422,7 @@ func TestProcessPolicyTemplatesWithBotman(t *testing.T) {
 		"exportJSONWithoutKeys":                  exportJSONWithoutKeys,
 		"getCustomBotCategoryNameByID":           getCustomBotCategoryNameByID,
 		"getCustomBotCategoryResourceNamesByIDs": getCustomBotCategoryResourceNamesByIDs,
+		"getCustomClientResourceNamesByIDs":      getCustomClientResourceNamesByIDs,
 	}
 
 	// Template to path mappings

--- a/pkg/providers/appsec/templates/imports.tmpl
+++ b/pkg/providers/appsec/templates/imports.tmpl
@@ -184,6 +184,9 @@ terraform import module.security.akamai_botman_custom_defined_bot.{{escapeName (
 terraform import module.security.akamai_botman_custom_client.{{escapeName (index . "customClientName")}}_{{index . "customClientId"}} {{ $configID }}:{{index . "customClientId"}}
 {{ end -}}
 {{ end -}}
+{{ if .CustomClientSequence  -}}
+terraform import module.security.akamai_botman_custom_client_sequence.sequence {{ $configID }}
+{{ end -}}
 {{ if .ResponseActions  -}}
 {{ if .ResponseActions.ServeAlternateActions  -}}
 {{ range .ResponseActions.ServeAlternateActions  -}}

--- a/pkg/providers/appsec/templates/modules-security-custom-client.tmpl
+++ b/pkg/providers/appsec/templates/modules-security-custom-client.tmpl
@@ -9,3 +9,11 @@ resource "akamai_botman_custom_client" "{{ escapeName (index . "customClientName
 
 {{ end -}}
 {{ end -}}
+{{ if .CustomClientSequence  -}}
+resource "akamai_botman_custom_client_sequence" "sequence" {
+    config_id         = akamai_appsec_configuration.config.config_id
+    custom_client_ids = [
+        {{getCustomClientResourceNamesByIDs .CustomClients .CustomClientSequence}}
+    ]
+}
+{{ end -}}

--- a/pkg/providers/appsec/testdata/ase-botman.json
+++ b/pkg/providers/appsec/testdata/ase-botman.json
@@ -3869,6 +3869,10 @@
             }
         }
     ],
+    "customClientSequence": [
+        "a7fe489d-0354-43bd-b81c-8cabbe850cdd",
+        "60374346-2d1d-444d-91c1-90373e3f804a"
+    ],
     "customDefinedBots": [
         {
             "botId": "50789280-ba99-4f8f-b4c6-ad9c1c69569a",

--- a/pkg/providers/appsec/testdata/ase-botman/appsec-import.sh
+++ b/pkg/providers/appsec/testdata/ase-botman/appsec-import.sh
@@ -228,6 +228,7 @@ terraform import module.security.akamai_botman_custom_defined_bot.bot_a_50789280
 terraform import module.security.akamai_botman_custom_defined_bot.bot_b_da1de35e-deda-4273-933d-3131291fa3d4 79947:da1de35e-deda-4273-933d-3131291fa3d4
 terraform import module.security.akamai_botman_custom_client.custom_client_a_a7fe489d-0354-43bd-b81c-8cabbe850cdd 79947:a7fe489d-0354-43bd-b81c-8cabbe850cdd
 terraform import module.security.akamai_botman_custom_client.custom_client_b_60374346-2d1d-444d-91c1-90373e3f804a 79947:60374346-2d1d-444d-91c1-90373e3f804a
+terraform import module.security.akamai_botman_custom_client_sequence.sequence 79947
 terraform import module.security.akamai_botman_serve_alternate_action.serve_alternate_action_a_action_A 79947:action_A
 terraform import module.security.akamai_botman_serve_alternate_action.serve_alternate_action_b_action_B 79947:action_B
 terraform import module.security.akamai_botman_challenge_action.challenge_action_a_action_A 79947:action_A

--- a/pkg/providers/appsec/testdata/ase-botman/modules/security/custom-client.tf
+++ b/pkg/providers/appsec/testdata/ase-botman/modules/security/custom-client.tf
@@ -32,3 +32,10 @@ resource "akamai_botman_custom_client" "custom_client_b_60374346-2d1d-444d-91c1-
   )
 }
 
+resource "akamai_botman_custom_client_sequence" "sequence" {
+  config_id = akamai_appsec_configuration.config.config_id
+  custom_client_ids = [
+    akamai_botman_custom_client.custom_client_a_a7fe489d-0354-43bd-b81c-8cabbe850cdd.custom_client_id,
+    akamai_botman_custom_client.custom_client_b_60374346-2d1d-444d-91c1-90373e3f804a.custom_client_id
+  ]
+}

--- a/pkg/providers/cloudwrapper/create_configuration.go
+++ b/pkg/providers/cloudwrapper/create_configuration.go
@@ -1,0 +1,170 @@
+// Package cloudwrapper contains code for exporting CloudWrapper configuration
+package cloudwrapper
+
+import (
+	"context"
+	"embed"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v7/pkg/cloudwrapper"
+	"github.com/akamai/cli-terraform/pkg/edgegrid"
+	"github.com/akamai/cli-terraform/pkg/templates"
+	"github.com/akamai/cli-terraform/pkg/tools"
+	"github.com/akamai/cli/pkg/terminal"
+	"github.com/fatih/color"
+	"github.com/urfave/cli/v2"
+)
+
+type (
+	// TFCloudWrapperData represents the data used in CloudWrapper
+	TFCloudWrapperData struct {
+		Configuration TFCWConfiguration
+		Section       string
+	}
+
+	// TFCWConfiguration represents the data used for export CloudWrapper configuration
+	TFCWConfiguration struct {
+		ConfigurationResourceName string
+		ID                        int64
+		ContractID                string
+		Name                      string
+		PropertyIDs               []string
+		Comments                  string
+		Status                    string
+		NotificationEmails        []string
+		RetainIdleObjects         bool
+		CapacityAlertsThreshold   *int
+		Locations                 []Location
+		IsActive                  bool
+	}
+
+	// Location represents CloudWrapper location
+	Location struct {
+		TrafficTypeID int
+		Comments      string
+		Capacity      Capacity
+	}
+
+	// Capacity represents capacity of location
+	Capacity struct {
+		Value int64
+		Unit  string
+	}
+)
+
+//go:embed templates/*
+var templateFiles embed.FS
+
+var (
+	// ErrFetchingConfiguration is returned when problem occurred during fetching configuration
+	ErrFetchingConfiguration = errors.New("problem with fetching configuration")
+	// ErrContainMultiCDNSettings is returned when configuration contains Multi CDN Setting
+	ErrContainMultiCDNSettings = errors.New("configuration contains Multi CDN Settings")
+	// ErrExportingCloudWrapper is returned when there is an issue related to export of CloudWrapper
+	ErrExportingCloudWrapper = errors.New("error exporting CloudWrapper")
+	// ErrSavingFiles is returned when an issue with processing templates occurs
+	ErrSavingFiles = errors.New("saving terraform project files")
+)
+
+// CmdCreateCloudWrapper is an entrypoint to export-cloudwrapper command
+func CmdCreateCloudWrapper(c *cli.Context) error {
+	ctx := c.Context
+	sess := edgegrid.GetSession(ctx)
+	client := cloudwrapper.Client(sess)
+
+	// tfWorkPath is a target directory for generated terraform resources
+	var tfWorkPath = "./"
+	if c.IsSet("tfworkpath") {
+		tfWorkPath = c.String("tfworkpath")
+	}
+	cloudwrapperPath := filepath.Join(tfWorkPath, "cloudwrapper.tf")
+	variablesPath := filepath.Join(tfWorkPath, "variables.tf")
+	importPath := filepath.Join(tfWorkPath, "import.sh")
+	if err := tools.CheckFiles(cloudwrapperPath, variablesPath, importPath); err != nil {
+		return cli.Exit(color.RedString(err.Error()), 1)
+	}
+
+	templateToFile := map[string]string{
+		"cloudwrapper.tmpl": cloudwrapperPath,
+		"variables.tmpl":    variablesPath,
+		"imports.tmpl":      importPath,
+	}
+
+	processor := templates.FSTemplateProcessor{
+		TemplatesFS:     templateFiles,
+		TemplateTargets: templateToFile,
+	}
+	configID, err := strconv.ParseInt(c.Args().Get(0), 10, 64)
+	if err != nil {
+		return cli.Exit(color.RedString(err.Error()), 1)
+	}
+	section := edgegrid.GetEdgercSection(c)
+	if err = createCloudWrapper(ctx, configID, section, client, processor); err != nil {
+		return cli.Exit(color.RedString(fmt.Sprintf("Error exporting cloudwraper: %s", err)), 1)
+	}
+	return nil
+}
+
+func createCloudWrapper(ctx context.Context, configID int64, section string, client cloudwrapper.CloudWrapper, templateProcessor templates.TemplateProcessor) error {
+	term := terminal.Get(ctx)
+	term.Spinner().Start("Fetching configuration " + strconv.Itoa(int(configID)))
+	configuration, err := client.GetConfiguration(ctx, cloudwrapper.GetConfigurationRequest{
+		ConfigID: configID,
+	})
+	if err != nil {
+		term.Spinner().Fail()
+		return fmt.Errorf("%w: %s", ErrFetchingConfiguration, err)
+	}
+	if configuration.MultiCDNSettings != nil {
+		term.Spinner().Fail()
+		return fmt.Errorf("%s: %w", ErrExportingCloudWrapper, ErrContainMultiCDNSettings)
+	}
+	tfCloudWrapperData := populateCloudWrapperData(configID, section, configuration)
+
+	term.Spinner().Start("Saving TF configurations ")
+	if err = templateProcessor.ProcessTemplates(tfCloudWrapperData); err != nil {
+		term.Spinner().Fail()
+		return fmt.Errorf("%w: %s", ErrSavingFiles, err)
+	}
+
+	term.Spinner().OK()
+	term.Printf("Terraform configuration for CloudWrapper configuration '%d' was saved successfully\n", tfCloudWrapperData.Configuration.ID)
+
+	return nil
+}
+
+func populateCloudWrapperData(configID int64, section string, configuration *cloudwrapper.Configuration) TFCloudWrapperData {
+	tfCloudWrapperData := TFCloudWrapperData{
+		Configuration: TFCWConfiguration{
+			ID:                        configID,
+			ContractID:                configuration.ContractID,
+			PropertyIDs:               configuration.PropertyIDs,
+			Name:                      configuration.ConfigName,
+			Comments:                  configuration.Comments,
+			NotificationEmails:        configuration.NotificationEmails,
+			ConfigurationResourceName: strings.ReplaceAll(configuration.ConfigName, "-", "_"),
+			RetainIdleObjects:         configuration.RetainIdleObjects,
+			CapacityAlertsThreshold:   configuration.CapacityAlertsThreshold,
+		},
+		Section: section,
+	}
+	tfCloudWrapperData.Configuration.Status = string(configuration.Status)
+	for _, configLocation := range configuration.Locations {
+		tfCloudWrapperData.Configuration.Locations = append(tfCloudWrapperData.Configuration.Locations, Location{
+			TrafficTypeID: configLocation.TrafficTypeID,
+			Comments:      configLocation.Comments,
+			Capacity: Capacity{
+				Unit:  string(configLocation.Capacity.Unit),
+				Value: configLocation.Capacity.Value,
+			},
+		})
+	}
+	if tfCloudWrapperData.Configuration.Status == string(cloudwrapper.StatusActive) {
+		tfCloudWrapperData.Configuration.IsActive = true
+	}
+	return tfCloudWrapperData
+}

--- a/pkg/providers/cloudwrapper/create_configuration_test.go
+++ b/pkg/providers/cloudwrapper/create_configuration_test.go
@@ -1,0 +1,336 @@
+package cloudwrapper
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v7/pkg/cloudwrapper"
+	"github.com/akamai/cli-terraform/pkg/templates"
+	"github.com/akamai/cli-terraform/pkg/tools"
+	"github.com/akamai/cli/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	section                              = "test_section"
+	configID                             = 12345
+	getConfigurationReq                  = cloudwrapper.GetConfigurationRequest{ConfigID: int64(configID)}
+	getConfigurationActiveResponse       = generateCloudWrapperResponseMock(cloudwrapper.StatusActive, false)
+	getConfigurationNoActiveResponse     = generateCloudWrapperResponseMock(cloudwrapper.StatusFailed, false)
+	getConfigurationResponseWithMultiCDN = generateCloudWrapperResponseMock(cloudwrapper.StatusActive, true)
+	processor                            = func(testdir string) templates.FSTemplateProcessor {
+		return templates.FSTemplateProcessor{
+			TemplatesFS: templateFiles,
+			TemplateTargets: map[string]string{
+				"cloudwrapper.tmpl": fmt.Sprintf("./testdata/res/%s/cloudwrapper.tf", testdir),
+				"variables.tmpl":    fmt.Sprintf("./testdata/res/%s/variables.tf", testdir),
+				"imports.tmpl":      fmt.Sprintf("./testdata/res/%s/import.sh", testdir),
+			},
+		}
+	}
+)
+
+func TestCreateCloudWrapper(t *testing.T) {
+	tests := map[string]struct {
+		init      func(*cloudwrapper.Mock, *templates.MockProcessor, string)
+		dir       string
+		withError error
+	}{
+		"configuration all fields": {
+			init: func(c *cloudwrapper.Mock, p *templates.MockProcessor, dir string) {
+				mockGetConfiguration(c, getConfigurationReq, &getConfigurationActiveResponse, nil)
+				mockProcessTemplates(p, (&tfCloudWrapperDataBuilder{}).withDefaults().withStatus(cloudwrapper.StatusActive).build(), nil)
+			},
+			dir: "all_fields_config",
+		},
+		"configuration not active status": {
+			init: func(c *cloudwrapper.Mock, p *templates.MockProcessor, dir string) {
+				mockGetConfiguration(c, getConfigurationReq, &getConfigurationNoActiveResponse, nil)
+				mockProcessTemplates(p, (&tfCloudWrapperDataBuilder{}).withDefaults().withStatus(cloudwrapper.StatusFailed).build(), nil)
+			},
+			dir: "not_active_configuration",
+		},
+		"error problem with fetching configuration": {
+			init: func(c *cloudwrapper.Mock, p *templates.MockProcessor, dir string) {
+				mockGetConfiguration(c, getConfigurationReq, nil, ErrFetchingConfiguration)
+			},
+			dir:       "all_fields_config",
+			withError: ErrFetchingConfiguration,
+		},
+		"error configuration contains multi cdn": {
+			init: func(c *cloudwrapper.Mock, p *templates.MockProcessor, dir string) {
+				mockGetConfiguration(c, getConfigurationReq, &getConfigurationResponseWithMultiCDN, nil)
+			},
+			dir:       "all_fields_config",
+			withError: ErrContainMultiCDNSettings,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.NoError(t, os.MkdirAll(fmt.Sprintf("./testdata/res/%s", test.dir), 0755))
+			mock := new(cloudwrapper.Mock)
+			templateProcessor := new(templates.MockProcessor)
+			test.init(mock, templateProcessor, test.dir)
+			ctx := terminal.Context(context.Background(), terminal.New(terminal.DiscardWriter(), nil, terminal.DiscardWriter()))
+			err := createCloudWrapper(ctx, int64(configID), section, mock, templateProcessor)
+			if test.withError != nil {
+				assert.True(t, errors.Is(err, test.withError), "expected: %s; got: %s", test.withError, err)
+				return
+			}
+			require.NoError(t, err)
+			mock.AssertExpectations(t)
+			templateProcessor.AssertExpectations(t)
+		})
+	}
+}
+
+func TestProcessCloudWrapperTemplates(t *testing.T) {
+	tests := map[string]struct {
+		givenData    TFCloudWrapperData
+		dir          string
+		filesToCheck []string
+	}{
+		"basic configuration with required fields": {
+			givenData: TFCloudWrapperData{
+				Configuration: TFCWConfiguration{
+					ID:                        int64(12345),
+					Comments:                  "test",
+					PropertyIDs:               []string{"123", "456"},
+					ContractID:                "1234",
+					ConfigurationResourceName: "test_configuration",
+					Name:                      "test_configuration",
+					Locations: []Location{
+						{
+							Comments:      "TestComments",
+							TrafficTypeID: 1,
+							Capacity: Capacity{
+								Unit:  "GB",
+								Value: 1,
+							},
+						},
+						{
+							Comments:      "TestComments",
+							TrafficTypeID: 2,
+							Capacity: Capacity{
+								Unit:  "TB",
+								Value: 2,
+							},
+						},
+					},
+				},
+				Section: section,
+			},
+			dir:          "basic_req_fields",
+			filesToCheck: []string{"cloudwrapper.tf", "import.sh", "variables.tf"},
+		},
+		"configuration with all fields": {
+			givenData: TFCloudWrapperData{
+				Configuration: TFCWConfiguration{
+					ID:                        int64(12345),
+					Comments:                  "test",
+					PropertyIDs:               []string{"123", "456"},
+					ContractID:                "1234",
+					ConfigurationResourceName: "test_configuration",
+					Name:                      "test_configuration",
+					NotificationEmails:        []string{"testuser@akamai.com"},
+					RetainIdleObjects:         false,
+					CapacityAlertsThreshold:   tools.IntPtr(75),
+					Status:                    string(cloudwrapper.StatusActive),
+					IsActive:                  true,
+					Locations: []Location{
+						{
+							Comments:      "TestComments",
+							TrafficTypeID: 1,
+							Capacity: Capacity{
+								Unit:  "GB",
+								Value: 1,
+							},
+						},
+						{
+							Comments:      "TestComments",
+							TrafficTypeID: 2,
+							Capacity: Capacity{
+								Unit:  "TB",
+								Value: 2,
+							},
+						},
+					},
+				},
+				Section: section,
+			},
+			dir:          "all_fields_config",
+			filesToCheck: []string{"cloudwrapper.tf", "import.sh", "variables.tf"},
+		},
+		"not active configuration": {
+			givenData: TFCloudWrapperData{
+				Configuration: TFCWConfiguration{
+					ID:                        int64(12345),
+					Comments:                  "test",
+					PropertyIDs:               []string{"123", "456"},
+					ContractID:                "1234",
+					ConfigurationResourceName: "test_configuration",
+					Name:                      "test_configuration",
+					NotificationEmails:        []string{"testuser@akamai.com"},
+					RetainIdleObjects:         false,
+					CapacityAlertsThreshold:   tools.IntPtr(75),
+					Status:                    string(cloudwrapper.StatusFailed),
+					IsActive:                  false,
+					Locations: []Location{
+						{
+							Comments:      "TestComments",
+							TrafficTypeID: 1,
+							Capacity: Capacity{
+								Unit:  "GB",
+								Value: 1,
+							},
+						},
+						{
+							Comments:      "TestComments",
+							TrafficTypeID: 2,
+							Capacity: Capacity{
+								Unit:  "TB",
+								Value: 2,
+							},
+						},
+					},
+				},
+				Section: section,
+			},
+			dir:          "not_active_configuration",
+			filesToCheck: []string{"cloudwrapper.tf", "import.sh", "variables.tf"},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.NoError(t, os.MkdirAll(fmt.Sprintf("./testdata/res/%s", test.dir), 0755))
+			require.NoError(t, processor(test.dir).ProcessTemplates(test.givenData))
+			for _, f := range test.filesToCheck {
+				expected, err := ioutil.ReadFile(fmt.Sprintf("./testdata/%s/%s", test.dir, f))
+				require.NoError(t, err)
+				result, err := ioutil.ReadFile(fmt.Sprintf("./testdata/res/%s/%s", test.dir, f))
+				require.NoError(t, err)
+				assert.Equal(t, string(expected), string(result))
+			}
+		})
+	}
+}
+
+func mockGetConfiguration(c *cloudwrapper.Mock, getConfigurationRequest cloudwrapper.GetConfigurationRequest, getConfigurationResponse *cloudwrapper.Configuration, err error) {
+	c.On("GetConfiguration", mock.Anything, getConfigurationRequest).
+		Return(getConfigurationResponse, err).Once()
+}
+
+func mockProcessTemplates(p *templates.MockProcessor, tfCloudWrapperData TFCloudWrapperData, err error) {
+	p.On("ProcessTemplates", tfCloudWrapperData).Return(err).Once()
+}
+
+type tfCloudWrapperDataBuilder struct {
+	tfCloudWrapperData TFCloudWrapperData
+}
+
+func (t *tfCloudWrapperDataBuilder) withDefaults() *tfCloudWrapperDataBuilder {
+	t.tfCloudWrapperData = TFCloudWrapperData{
+		Configuration: TFCWConfiguration{
+			ID:                        int64(12345),
+			Comments:                  "test",
+			PropertyIDs:               []string{"123", "456"},
+			ContractID:                "1234",
+			ConfigurationResourceName: "testName",
+			Name:                      "testName",
+			NotificationEmails:        []string{"testuser@akamai.com"},
+			RetainIdleObjects:         false,
+			CapacityAlertsThreshold:   tools.IntPtr(75),
+			Locations: []Location{
+				{
+					Comments:      "TestComments",
+					TrafficTypeID: 1,
+					Capacity: Capacity{
+						Unit:  "GB",
+						Value: 1,
+					},
+				},
+				{
+					Comments:      "TestComments",
+					TrafficTypeID: 2,
+					Capacity: Capacity{
+						Unit:  "TB",
+						Value: 2,
+					},
+				},
+			},
+		},
+		Section: "test_section",
+	}
+	return t
+}
+
+func (t *tfCloudWrapperDataBuilder) withStatus(status cloudwrapper.StatusType) *tfCloudWrapperDataBuilder {
+	t.tfCloudWrapperData.Configuration.Status = string(status)
+	if status == cloudwrapper.StatusActive {
+		t.tfCloudWrapperData.Configuration.IsActive = true
+	} else {
+		t.tfCloudWrapperData.Configuration.IsActive = false
+	}
+	return t
+}
+
+func (t *tfCloudWrapperDataBuilder) build() TFCloudWrapperData {
+	return t.tfCloudWrapperData
+}
+
+func generateCloudWrapperResponseMock(status cloudwrapper.StatusType, withMultiCDNSettings bool) cloudwrapper.Configuration {
+	configurationResponse := cloudwrapper.Configuration{
+		Status:                  status,
+		Comments:                "test",
+		ContractID:              "1234",
+		ConfigID:                12345,
+		CapacityAlertsThreshold: tools.IntPtr(75),
+		ConfigName:              "testName",
+		LastActivatedBy:         tools.StringPtr("user"),
+		LastActivatedDate:       tools.StringPtr("2018-03-07T23:40:45Z"),
+		LastUpdatedDate:         "2018-03-07T23:40:45Z",
+		LastUpdatedBy:           "testUser",
+		NotificationEmails:      []string{"testuser@akamai.com"},
+		PropertyIDs: []string{
+			"123",
+			"456",
+		},
+		RetainIdleObjects: false,
+		Locations: []cloudwrapper.ConfigLocationResp{
+			{
+				Comments:      "TestComments",
+				TrafficTypeID: 1,
+				Capacity: cloudwrapper.Capacity{
+					Unit:  "GB",
+					Value: 1,
+				},
+			},
+			{
+				Comments:      "TestComments",
+				TrafficTypeID: 2,
+				Capacity: cloudwrapper.Capacity{
+					Unit:  "TB",
+					Value: 2,
+				},
+			},
+		},
+	}
+	if withMultiCDNSettings {
+		configurationResponse.MultiCDNSettings =
+			&cloudwrapper.MultiCDNSettings{
+				CDNs: []cloudwrapper.CDN{
+					{
+						CDNCode: "testCode",
+					},
+				},
+			}
+	}
+
+	return configurationResponse
+}

--- a/pkg/providers/cloudwrapper/templates/cloudwrapper.tmpl
+++ b/pkg/providers/cloudwrapper/templates/cloudwrapper.tmpl
@@ -1,0 +1,50 @@
+{{- /*gotype: github.com/akamai/cli-terraform/pkg/providers/cloudwrapper.TFCloudWrapperData*/ -}}
+terraform {
+  required_providers {
+    akamai = {
+      source  = "akamai/akamai"
+      version = ">= 5.2.0"
+    }
+  }
+  required_version = ">= 0.13"
+}
+
+provider "akamai" {
+  edgerc         = var.edgerc_path
+  config_section = var.config_section
+}
+
+resource "akamai_cloudwrapper_configuration" "{{.Configuration.ConfigurationResourceName}}" {
+  config_name               = "{{.Configuration.Name}}"
+  contract_id               = "{{.Configuration.ContractID}}"
+  property_ids              =  [{{range $index, $element := .Configuration.PropertyIDs}}{{if $index}}, {{end}}"{{$element}}"{{end}}]
+  {{- if .Configuration.NotificationEmails }}
+  notification_emails       =  [{{range $index, $element := .Configuration.NotificationEmails}}{{if $index}}, {{end}}"{{$element}}"{{end}}]
+  {{- end}}
+  comments                  = "{{.Configuration.Comments}}"
+  retain_idle_objects       = {{.Configuration.RetainIdleObjects}}
+  {{- if .Configuration.CapacityAlertsThreshold }}
+  capacity_alerts_threshold = {{.Configuration.CapacityAlertsThreshold}}
+  {{- end}}
+  {{- range $index, $element := .Configuration.Locations}}
+  location {
+    traffic_type_id = {{$element.TrafficTypeID}}
+    comments        = "{{$element.Comments}}"
+    capacity {
+      value = {{$element.Capacity.Value}}
+      unit  = "{{$element.Capacity.Unit}}"
+    }
+  }
+  {{- end}}
+}
+{{ if .Configuration.IsActive }}
+resource "akamai_cloudwrapper_activation" "{{.Configuration.ConfigurationResourceName}}_activation" {
+  config_id = akamai_cloudwrapper_configuration.{{.Configuration.ConfigurationResourceName}}.id
+  revision  = akamai_cloudwrapper_configuration.{{.Configuration.ConfigurationResourceName}}.revision
+}
+{{- else }}
+#resource "akamai_cloudwrapper_activation" "{{.Configuration.ConfigurationResourceName}}_activation" {
+#  config_id = akamai_cloudwrapper_configuration.{{.Configuration.ConfigurationResourceName}}.id
+#  revision  = akamai_cloudwrapper_configuration.{{.Configuration.ConfigurationResourceName}}.revision
+#}
+{{- end }}

--- a/pkg/providers/cloudwrapper/templates/imports.tmpl
+++ b/pkg/providers/cloudwrapper/templates/imports.tmpl
@@ -1,0 +1,6 @@
+{{- /*gotype: github.com/akamai/cli-terraform/pkg/providers/cloudwrapper.TFCloudWrapperData*/ -}}
+terraform init
+terraform import akamai_cloudwrapper_configuration.{{.Configuration.ConfigurationResourceName}} {{.Configuration.ID}}
+{{ if .Configuration.IsActive -}}
+terraform import akamai_cloudwrapper_activation.{{.Configuration.ConfigurationResourceName}}_activation {{.Configuration.ID}}
+{{ end }}

--- a/pkg/providers/cloudwrapper/templates/variables.tmpl
+++ b/pkg/providers/cloudwrapper/templates/variables.tmpl
@@ -1,0 +1,10 @@
+{{- /*gotype: github.com/akamai/cli-terraform/pkg/providers/cloudwrapper.TFCloudWrapperData*/ -}}
+variable "edgerc_path" {
+  type = string
+  default = "~/.edgerc"
+}
+
+variable "config_section" {
+  type = string
+  default = "{{.Section}}"
+}

--- a/pkg/providers/cloudwrapper/testdata/all_fields_config/cloudwrapper.tf
+++ b/pkg/providers/cloudwrapper/testdata/all_fields_config/cloudwrapper.tf
@@ -1,0 +1,45 @@
+terraform {
+  required_providers {
+    akamai = {
+      source  = "akamai/akamai"
+      version = ">= 5.2.0"
+    }
+  }
+  required_version = ">= 0.13"
+}
+
+provider "akamai" {
+  edgerc         = var.edgerc_path
+  config_section = var.config_section
+}
+
+resource "akamai_cloudwrapper_configuration" "test_configuration" {
+  config_name               = "test_configuration"
+  contract_id               = "1234"
+  property_ids              = ["123", "456"]
+  notification_emails       = ["testuser@akamai.com"]
+  comments                  = "test"
+  retain_idle_objects       = false
+  capacity_alerts_threshold = 75
+  location {
+    traffic_type_id = 1
+    comments        = "TestComments"
+    capacity {
+      value = 1
+      unit  = "GB"
+    }
+  }
+  location {
+    traffic_type_id = 2
+    comments        = "TestComments"
+    capacity {
+      value = 2
+      unit  = "TB"
+    }
+  }
+}
+
+resource "akamai_cloudwrapper_activation" "test_configuration_activation" {
+  config_id = akamai_cloudwrapper_configuration.test_configuration.id
+  revision  = akamai_cloudwrapper_configuration.test_configuration.revision
+}

--- a/pkg/providers/cloudwrapper/testdata/all_fields_config/import.sh
+++ b/pkg/providers/cloudwrapper/testdata/all_fields_config/import.sh
@@ -1,0 +1,3 @@
+terraform init
+terraform import akamai_cloudwrapper_configuration.test_configuration 12345
+terraform import akamai_cloudwrapper_activation.test_configuration_activation 12345

--- a/pkg/providers/cloudwrapper/testdata/all_fields_config/variables.tf
+++ b/pkg/providers/cloudwrapper/testdata/all_fields_config/variables.tf
@@ -1,0 +1,9 @@
+variable "edgerc_path" {
+  type    = string
+  default = "~/.edgerc"
+}
+
+variable "config_section" {
+  type    = string
+  default = "test_section"
+}

--- a/pkg/providers/cloudwrapper/testdata/basic_req_fields/cloudwrapper.tf
+++ b/pkg/providers/cloudwrapper/testdata/basic_req_fields/cloudwrapper.tf
@@ -1,0 +1,43 @@
+terraform {
+  required_providers {
+    akamai = {
+      source  = "akamai/akamai"
+      version = ">= 5.2.0"
+    }
+  }
+  required_version = ">= 0.13"
+}
+
+provider "akamai" {
+  edgerc         = var.edgerc_path
+  config_section = var.config_section
+}
+
+resource "akamai_cloudwrapper_configuration" "test_configuration" {
+  config_name         = "test_configuration"
+  contract_id         = "1234"
+  property_ids        = ["123", "456"]
+  comments            = "test"
+  retain_idle_objects = false
+  location {
+    traffic_type_id = 1
+    comments        = "TestComments"
+    capacity {
+      value = 1
+      unit  = "GB"
+    }
+  }
+  location {
+    traffic_type_id = 2
+    comments        = "TestComments"
+    capacity {
+      value = 2
+      unit  = "TB"
+    }
+  }
+}
+
+#resource "akamai_cloudwrapper_activation" "test_configuration_activation" {
+#  config_id = akamai_cloudwrapper_configuration.test_configuration.id
+#  revision  = akamai_cloudwrapper_configuration.test_configuration.revision
+#}

--- a/pkg/providers/cloudwrapper/testdata/basic_req_fields/import.sh
+++ b/pkg/providers/cloudwrapper/testdata/basic_req_fields/import.sh
@@ -1,0 +1,2 @@
+terraform init
+terraform import akamai_cloudwrapper_configuration.test_configuration 12345

--- a/pkg/providers/cloudwrapper/testdata/basic_req_fields/variables.tf
+++ b/pkg/providers/cloudwrapper/testdata/basic_req_fields/variables.tf
@@ -1,0 +1,9 @@
+variable "edgerc_path" {
+  type    = string
+  default = "~/.edgerc"
+}
+
+variable "config_section" {
+  type    = string
+  default = "test_section"
+}

--- a/pkg/providers/cloudwrapper/testdata/not_active_configuration/cloudwrapper.tf
+++ b/pkg/providers/cloudwrapper/testdata/not_active_configuration/cloudwrapper.tf
@@ -1,0 +1,45 @@
+terraform {
+  required_providers {
+    akamai = {
+      source  = "akamai/akamai"
+      version = ">= 5.2.0"
+    }
+  }
+  required_version = ">= 0.13"
+}
+
+provider "akamai" {
+  edgerc         = var.edgerc_path
+  config_section = var.config_section
+}
+
+resource "akamai_cloudwrapper_configuration" "test_configuration" {
+  config_name               = "test_configuration"
+  contract_id               = "1234"
+  property_ids              = ["123", "456"]
+  notification_emails       = ["testuser@akamai.com"]
+  comments                  = "test"
+  retain_idle_objects       = false
+  capacity_alerts_threshold = 75
+  location {
+    traffic_type_id = 1
+    comments        = "TestComments"
+    capacity {
+      value = 1
+      unit  = "GB"
+    }
+  }
+  location {
+    traffic_type_id = 2
+    comments        = "TestComments"
+    capacity {
+      value = 2
+      unit  = "TB"
+    }
+  }
+}
+
+#resource "akamai_cloudwrapper_activation" "test_configuration_activation" {
+#  config_id = akamai_cloudwrapper_configuration.test_configuration.id
+#  revision  = akamai_cloudwrapper_configuration.test_configuration.revision
+#}

--- a/pkg/providers/cloudwrapper/testdata/not_active_configuration/import.sh
+++ b/pkg/providers/cloudwrapper/testdata/not_active_configuration/import.sh
@@ -1,0 +1,2 @@
+terraform init
+terraform import akamai_cloudwrapper_configuration.test_configuration 12345

--- a/pkg/providers/cloudwrapper/testdata/not_active_configuration/variables.tf
+++ b/pkg/providers/cloudwrapper/testdata/not_active_configuration/variables.tf
@@ -1,0 +1,9 @@
+variable "edgerc_path" {
+  type    = string
+  default = "~/.edgerc"
+}
+
+variable "config_section" {
+  type    = string
+  default = "test_section"
+}

--- a/pkg/providers/papi/templates/property.tmpl
+++ b/pkg/providers/papi/templates/property.tmpl
@@ -14,14 +14,6 @@ provider "akamai" {
   config_section = var.config_section
 }
 
-data "akamai_group" "group" {
-  group_name = "{{.Property.GroupName}}"
-  contract_id = "{{.Property.ContractID}}"
-}
-
-data "akamai_contract" "contract" {
-  group_name = data.akamai_group.group.group_name
-}
 {{- if not .RulesAsSchema}}
 
 data "akamai_property_rules_template" "rules" {
@@ -29,8 +21,8 @@ data "akamai_property_rules_template" "rules" {
 }{{end}}
 {{range .Property.EdgeHostnames}}
 resource "akamai_edge_hostname" "{{.EdgeHostnameResourceName}}" {
-  contract_id = data.akamai_contract.contract.id
-  group_id = data.akamai_group.group.id
+  contract_id = var.contract_id
+  group_id = var.group_id
   ip_behavior = "{{.IPv6}}"
   edge_hostname = "{{.EdgeHostname}}"
 {{- if .UseCases}}
@@ -40,8 +32,8 @@ resource "akamai_edge_hostname" "{{.EdgeHostnameResourceName}}" {
 {{end}}
 resource "akamai_property" "{{.Property.PropertyResourceName}}" {
   name = "{{.Property.PropertyName}}"
-  contract_id = data.akamai_contract.contract.id
-  group_id = data.akamai_group.group.id
+  contract_id = var.contract_id
+  group_id = var.group_id
   product_id = "prd_{{.Property.ProductName}}"
 {{- range .Property.Hostnames}}
   hostnames {

--- a/pkg/providers/papi/templates/rules_v2023-05-30.tmpl
+++ b/pkg/providers/papi/templates/rules_v2023-05-30.tmpl
@@ -2258,8 +2258,8 @@ datastream {
 {{- if and (eq $k "logEnabled") (ne $v nil)}}
 		log_enabled = {{$v}}
 {{- end}}
-{{- if and (eq $k "logStreamName") (ne $v nil)}}
-        log_stream_name = {{template "Text" $v}}
+{{- if eq $k "logStreamName"}}
+		log_stream_name = [{{range $v}}"{{. | Escape}}", {{end}}]
 {{- end}}
 {{- if and (eq $k "samplingPercentage") (ne $v nil)}}
 		sampling_percentage = {{$v | AsInt}}

--- a/pkg/providers/papi/templates/variables.tmpl
+++ b/pkg/providers/papi/templates/variables.tmpl
@@ -8,3 +8,14 @@ variable "config_section" {
   type = string
   default = "{{.Section}}"
 }
+{{ if .Property.PropertyName }}
+variable "contract_id" {
+  type = string
+  default = "{{.Property.ContractID}}"
+}
+
+variable "group_id" {
+  type = string
+  default = "{{.Property.GroupID}}"
+}
+{{- end}}

--- a/pkg/providers/papi/testdata/basic-rules-datasource-schema1/property.tf
+++ b/pkg/providers/papi/testdata/basic-rules-datasource-schema1/property.tf
@@ -13,19 +13,10 @@ provider "akamai" {
   config_section = var.config_section
 }
 
-data "akamai_group" "group" {
-  group_name  = "test_group"
-  contract_id = "test_contract"
-}
-
-data "akamai_contract" "contract" {
-  group_name = data.akamai_group.group.group_name
-}
-
 resource "akamai_property" "test-edgesuite-net" {
   name        = "test.edgesuite.net"
-  contract_id = data.akamai_contract.contract.id
-  group_id    = data.akamai_group.group.id
+  contract_id = var.contract_id
+  group_id    = var.group_id
   product_id  = "prd_HTTP_Content_Del"
   rule_format = data.akamai_property_rules_builder.test-edgesuite-net_rule_default.rule_format
   rules       = data.akamai_property_rules_builder.test-edgesuite-net_rule_default.json

--- a/pkg/providers/papi/testdata/basic-rules-datasource-schema1/variables.tf
+++ b/pkg/providers/papi/testdata/basic-rules-datasource-schema1/variables.tf
@@ -7,3 +7,13 @@ variable "config_section" {
   type    = string
   default = "test_section"
 }
+
+variable "contract_id" {
+  type    = string
+  default = "test_contract"
+}
+
+variable "group_id" {
+  type    = string
+  default = "grp_12345"
+}

--- a/pkg/providers/papi/testdata/basic-rules-datasource-schema2/mock_rules.json
+++ b/pkg/providers/papi/testdata/basic-rules-datasource-schema2/mock_rules.json
@@ -16,7 +16,9 @@
           "datastreamIds": "77-85-6",
           "enabled": true,
           "logEnabled": false,
-          "logStreamName": "60",
+          "logStreamName": [
+            "60"
+          ],
           "logStreamTitle": "test",
           "samplingPercentage": 100,
           "streamType": "LOG"

--- a/pkg/providers/papi/testdata/basic-rules-datasource-schema2/property.tf
+++ b/pkg/providers/papi/testdata/basic-rules-datasource-schema2/property.tf
@@ -13,19 +13,10 @@ provider "akamai" {
   config_section = var.config_section
 }
 
-data "akamai_group" "group" {
-  group_name  = "test_group"
-  contract_id = "test_contract"
-}
-
-data "akamai_contract" "contract" {
-  group_name = data.akamai_group.group.group_name
-}
-
 resource "akamai_property" "test-edgesuite-net" {
   name        = "test.edgesuite.net"
-  contract_id = data.akamai_contract.contract.id
-  group_id    = data.akamai_group.group.id
+  contract_id = var.contract_id
+  group_id    = var.group_id
   product_id  = "prd_HTTP_Content_Del"
   rule_format = data.akamai_property_rules_builder.test-edgesuite-net_rule_default.rule_format
   rules       = data.akamai_property_rules_builder.test-edgesuite-net_rule_default.json

--- a/pkg/providers/papi/testdata/basic-rules-datasource-schema2/rules.tf
+++ b/pkg/providers/papi/testdata/basic-rules-datasource-schema2/rules.tf
@@ -11,7 +11,7 @@ data "akamai_property_rules_builder" "test-edgesuite-net_rule_default" {
         datastream_ids           = "77-85-6"
         enabled                  = true
         log_enabled              = false
-        log_stream_name          = "60"
+        log_stream_name          = ["60", ]
         log_stream_title         = "test"
         sampling_percentage      = 100
         stream_type              = "LOG"

--- a/pkg/providers/papi/testdata/basic-rules-datasource-schema2/variables.tf
+++ b/pkg/providers/papi/testdata/basic-rules-datasource-schema2/variables.tf
@@ -7,3 +7,13 @@ variable "config_section" {
   type    = string
   default = "test_section"
 }
+
+variable "contract_id" {
+  type    = string
+  default = "test_contract"
+}
+
+variable "group_id" {
+  type    = string
+  default = "grp_12345"
+}

--- a/pkg/providers/papi/testdata/basic-rules-datasource/property.tf
+++ b/pkg/providers/papi/testdata/basic-rules-datasource/property.tf
@@ -13,26 +13,17 @@ provider "akamai" {
   config_section = var.config_section
 }
 
-data "akamai_group" "group" {
-  group_name  = "test_group"
-  contract_id = "test_contract"
-}
-
-data "akamai_contract" "contract" {
-  group_name = data.akamai_group.group.group_name
-}
-
 resource "akamai_edge_hostname" "test-edgesuite-net" {
-  contract_id   = data.akamai_contract.contract.id
-  group_id      = data.akamai_group.group.id
+  contract_id   = var.contract_id
+  group_id      = var.group_id
   ip_behavior   = "IPV6_COMPLIANCE"
   edge_hostname = "test.edgesuite.net"
 }
 
 resource "akamai_property" "test-edgesuite-net" {
   name        = "test.edgesuite.net"
-  contract_id = data.akamai_contract.contract.id
-  group_id    = data.akamai_group.group.id
+  contract_id = var.contract_id
+  group_id    = var.group_id
   product_id  = "prd_HTTP_Content_Del"
   hostnames {
     cname_from             = "test.edgesuite.net"

--- a/pkg/providers/papi/testdata/basic-rules-datasource/variables.tf
+++ b/pkg/providers/papi/testdata/basic-rules-datasource/variables.tf
@@ -7,3 +7,13 @@ variable "config_section" {
   type    = string
   default = "test_section"
 }
+
+variable "contract_id" {
+  type    = string
+  default = "test_contract"
+}
+
+variable "group_id" {
+  type    = string
+  default = "grp_12345"
+}

--- a/pkg/providers/papi/testdata/basic-v1/property.tf
+++ b/pkg/providers/papi/testdata/basic-v1/property.tf
@@ -27,16 +27,16 @@ data "akamai_property_rules_template" "rules" {
 }
 
 resource "akamai_edge_hostname" "test-edgesuite-net" {
-  contract_id   = data.akamai_contract.contract.id
-  group_id      = data.akamai_group.group.id
+  contract_id   = var.contract_id
+  group_id      = var.group_id
   ip_behavior   = "IPV6_COMPLIANCE"
   edge_hostname = "test.edgesuite.net"
 }
 
 resource "akamai_property" "test-edgesuite-net" {
   name        = "test.edgesuite.net"
-  contract_id = data.akamai_contract.contract.id
-  group_id    = data.akamai_group.group.id
+  contract_id = var.contract_id
+  group_id    = var.group_id
   product_id  = "prd_HTTP_Content_Del"
   hostnames {
     cname_from             = "test.edgesuite.net"

--- a/pkg/providers/papi/testdata/basic-v1/variables.tf
+++ b/pkg/providers/papi/testdata/basic-v1/variables.tf
@@ -7,3 +7,13 @@ variable "config_section" {
   type    = string
   default = "test_section"
 }
+
+variable "contract_id" {
+  type    = string
+  default = "test_contract"
+}
+
+variable "group_id" {
+  type    = string
+  default = "grp_12345"
+}

--- a/pkg/providers/papi/testdata/basic/property.tf
+++ b/pkg/providers/papi/testdata/basic/property.tf
@@ -13,30 +13,21 @@ provider "akamai" {
   config_section = var.config_section
 }
 
-data "akamai_group" "group" {
-  group_name  = "test_group"
-  contract_id = "test_contract"
-}
-
-data "akamai_contract" "contract" {
-  group_name = data.akamai_group.group.group_name
-}
-
 data "akamai_property_rules_template" "rules" {
   template_file = abspath("${path.module}/property-snippets/main.json")
 }
 
 resource "akamai_edge_hostname" "test-edgesuite-net" {
-  contract_id   = data.akamai_contract.contract.id
-  group_id      = data.akamai_group.group.id
+  contract_id   = var.contract_id
+  group_id      = var.group_id
   ip_behavior   = "IPV6_COMPLIANCE"
   edge_hostname = "test.edgesuite.net"
 }
 
 resource "akamai_property" "test-edgesuite-net" {
   name        = "test.edgesuite.net"
-  contract_id = data.akamai_contract.contract.id
-  group_id    = data.akamai_group.group.id
+  contract_id = var.contract_id
+  group_id    = var.group_id
   product_id  = "prd_HTTP_Content_Del"
   hostnames {
     cname_from             = "test.edgesuite.net"

--- a/pkg/providers/papi/testdata/basic/variables.tf
+++ b/pkg/providers/papi/testdata/basic/variables.tf
@@ -7,3 +7,13 @@ variable "config_section" {
   type    = string
   default = "test_section"
 }
+
+variable "contract_id" {
+  type    = string
+  default = "test_contract"
+}
+
+variable "group_id" {
+  type    = string
+  default = "grp_12345"
+}

--- a/pkg/providers/papi/testdata/basic_property_with_empty_hostname_id/property.tf
+++ b/pkg/providers/papi/testdata/basic_property_with_empty_hostname_id/property.tf
@@ -13,14 +13,7 @@ provider "akamai" {
   config_section = var.config_section
 }
 
-data "akamai_group" "group" {
-  group_name  = "test_group"
-  contract_id = "test_contract"
-}
 
-data "akamai_contract" "contract" {
-  group_name = data.akamai_group.group.group_name
-}
 
 data "akamai_property_rules_template" "rules" {
   template_file = abspath("${path.module}/property-snippets/main.json")
@@ -28,8 +21,8 @@ data "akamai_property_rules_template" "rules" {
 
 resource "akamai_property" "test-edgesuite-net" {
   name        = "test.edgesuite.net"
-  contract_id = data.akamai_contract.contract.id
-  group_id    = data.akamai_group.group.id
+  contract_id = var.contract_id
+  group_id    = var.group_id
   product_id  = "prd_HTTP_Content_Del"
   rule_format = "latest"
   hostnames {

--- a/pkg/providers/papi/testdata/basic_property_with_empty_hostname_id/variables.tf
+++ b/pkg/providers/papi/testdata/basic_property_with_empty_hostname_id/variables.tf
@@ -7,3 +7,13 @@ variable "config_section" {
   type    = string
   default = "test_section"
 }
+
+variable "contract_id" {
+  type    = string
+  default = "test_contract"
+}
+
+variable "group_id" {
+  type    = string
+  default = "grp_12345"
+}

--- a/pkg/providers/papi/testdata/basic_property_with_include/property.tf
+++ b/pkg/providers/papi/testdata/basic_property_with_include/property.tf
@@ -13,30 +13,21 @@ provider "akamai" {
   config_section = var.config_section
 }
 
-data "akamai_group" "group" {
-  group_name  = "test_group"
-  contract_id = "test_contract"
-}
-
-data "akamai_contract" "contract" {
-  group_name = data.akamai_group.group.group_name
-}
-
 data "akamai_property_rules_template" "rules" {
   template_file = abspath("${path.module}/property-snippets/main.json")
 }
 
 resource "akamai_edge_hostname" "test-edgesuite-net" {
-  contract_id   = data.akamai_contract.contract.id
-  group_id      = data.akamai_group.group.id
+  contract_id   = var.contract_id
+  group_id      = var.group_id
   ip_behavior   = "IPV6_COMPLIANCE"
   edge_hostname = "test.edgesuite.net"
 }
 
 resource "akamai_property" "test-edgesuite-net" {
   name        = "test.edgesuite.net"
-  contract_id = data.akamai_contract.contract.id
-  group_id    = data.akamai_group.group.id
+  contract_id = var.contract_id
+  group_id    = var.group_id
   product_id  = "prd_HTTP_Content_Del"
   hostnames {
     cname_from             = "test.edgesuite.net"

--- a/pkg/providers/papi/testdata/basic_property_with_include/variables.tf
+++ b/pkg/providers/papi/testdata/basic_property_with_include/variables.tf
@@ -7,3 +7,13 @@ variable "config_section" {
   type    = string
   default = "test_section"
 }
+
+variable "contract_id" {
+  type    = string
+  default = "test_contract"
+}
+
+variable "group_id" {
+  type    = string
+  default = "grp_12345"
+}

--- a/pkg/providers/papi/testdata/basic_property_with_multiple_includes/property.tf
+++ b/pkg/providers/papi/testdata/basic_property_with_multiple_includes/property.tf
@@ -13,30 +13,21 @@ provider "akamai" {
   config_section = var.config_section
 }
 
-data "akamai_group" "group" {
-  group_name  = "test_group"
-  contract_id = "test_contract"
-}
-
-data "akamai_contract" "contract" {
-  group_name = data.akamai_group.group.group_name
-}
-
 data "akamai_property_rules_template" "rules" {
   template_file = abspath("${path.module}/property-snippets/main.json")
 }
 
 resource "akamai_edge_hostname" "test-edgesuite-net" {
-  contract_id   = data.akamai_contract.contract.id
-  group_id      = data.akamai_group.group.id
+  contract_id   = var.contract_id
+  group_id      = var.group_id
   ip_behavior   = "IPV6_COMPLIANCE"
   edge_hostname = "test.edgesuite.net"
 }
 
 resource "akamai_property" "test-edgesuite-net" {
   name        = "test.edgesuite.net"
-  contract_id = data.akamai_contract.contract.id
-  group_id    = data.akamai_group.group.id
+  contract_id = var.contract_id
+  group_id    = var.group_id
   product_id  = "prd_HTTP_Content_Del"
   hostnames {
     cname_from             = "test.edgesuite.net"

--- a/pkg/providers/papi/testdata/basic_property_with_multiple_includes/variables.tf
+++ b/pkg/providers/papi/testdata/basic_property_with_multiple_includes/variables.tf
@@ -7,3 +7,13 @@ variable "config_section" {
   type    = string
   default = "test_section"
 }
+
+variable "contract_id" {
+  type    = string
+  default = "test_contract"
+}
+
+variable "group_id" {
+  type    = string
+  default = "grp_12345"
+}

--- a/pkg/providers/papi/testdata/basic_property_with_multiple_includes_schema/property.tf
+++ b/pkg/providers/papi/testdata/basic_property_with_multiple_includes_schema/property.tf
@@ -13,26 +13,17 @@ provider "akamai" {
   config_section = var.config_section
 }
 
-data "akamai_group" "group" {
-  group_name  = "test_group"
-  contract_id = "test_contract"
-}
-
-data "akamai_contract" "contract" {
-  group_name = data.akamai_group.group.group_name
-}
-
 resource "akamai_edge_hostname" "test-edgesuite-net" {
-  contract_id   = data.akamai_contract.contract.id
-  group_id      = data.akamai_group.group.id
+  contract_id   = var.contract_id
+  group_id      = var.group_id
   ip_behavior   = "IPV6_COMPLIANCE"
   edge_hostname = "test.edgesuite.net"
 }
 
 resource "akamai_property" "test-edgesuite-net" {
   name        = "test.edgesuite.net"
-  contract_id = data.akamai_contract.contract.id
-  group_id    = data.akamai_group.group.id
+  contract_id = var.contract_id
+  group_id    = var.group_id
   product_id  = "prd_HTTP_Content_Del"
   hostnames {
     cname_from             = "test.edgesuite.net"

--- a/pkg/providers/papi/testdata/basic_property_with_multiple_includes_schema/variables.tf
+++ b/pkg/providers/papi/testdata/basic_property_with_multiple_includes_schema/variables.tf
@@ -7,3 +7,13 @@ variable "config_section" {
   type    = string
   default = "test_section"
 }
+
+variable "contract_id" {
+  type    = string
+  default = "test_contract"
+}
+
+variable "group_id" {
+  type    = string
+  default = "grp_12345"
+}

--- a/pkg/providers/papi/testdata/basic_with_activation_note/property.tf
+++ b/pkg/providers/papi/testdata/basic_with_activation_note/property.tf
@@ -13,30 +13,21 @@ provider "akamai" {
   config_section = var.config_section
 }
 
-data "akamai_group" "group" {
-  group_name  = "test_group"
-  contract_id = "test_contract"
-}
-
-data "akamai_contract" "contract" {
-  group_name = data.akamai_group.group.group_name
-}
-
 data "akamai_property_rules_template" "rules" {
   template_file = abspath("${path.module}/property-snippets/main.json")
 }
 
 resource "akamai_edge_hostname" "test-edgesuite-net" {
-  contract_id   = data.akamai_contract.contract.id
-  group_id      = data.akamai_group.group.id
+  contract_id   = var.contract_id
+  group_id      = var.group_id
   ip_behavior   = "IPV6_COMPLIANCE"
   edge_hostname = "test.edgesuite.net"
 }
 
 resource "akamai_property" "test-edgesuite-net" {
   name        = "test.edgesuite.net"
-  contract_id = data.akamai_contract.contract.id
-  group_id    = data.akamai_group.group.id
+  contract_id = var.contract_id
+  group_id    = var.group_id
   product_id  = "prd_HTTP_Content_Del"
   hostnames {
     cname_from             = "test.edgesuite.net"

--- a/pkg/providers/papi/testdata/basic_with_activation_note/variables.tf
+++ b/pkg/providers/papi/testdata/basic_with_activation_note/variables.tf
@@ -7,3 +7,13 @@ variable "config_section" {
   type    = string
   default = "test_section"
 }
+
+variable "contract_id" {
+  type    = string
+  default = "test_contract"
+}
+
+variable "group_id" {
+  type    = string
+  default = "grp_12345"
+}

--- a/pkg/providers/papi/testdata/basic_with_both_activations/property.tf
+++ b/pkg/providers/papi/testdata/basic_with_both_activations/property.tf
@@ -13,30 +13,21 @@ provider "akamai" {
   config_section = var.config_section
 }
 
-data "akamai_group" "group" {
-  group_name  = "test_group"
-  contract_id = "test_contract"
-}
-
-data "akamai_contract" "contract" {
-  group_name = data.akamai_group.group.group_name
-}
-
 data "akamai_property_rules_template" "rules" {
   template_file = abspath("${path.module}/property-snippets/main.json")
 }
 
 resource "akamai_edge_hostname" "test-edgesuite-net" {
-  contract_id   = data.akamai_contract.contract.id
-  group_id      = data.akamai_group.group.id
+  contract_id   = var.contract_id
+  group_id      = var.group_id
   ip_behavior   = "IPV6_COMPLIANCE"
   edge_hostname = "test.edgesuite.net"
 }
 
 resource "akamai_property" "test-edgesuite-net" {
   name        = "test.edgesuite.net"
-  contract_id = data.akamai_contract.contract.id
-  group_id    = data.akamai_group.group.id
+  contract_id = var.contract_id
+  group_id    = var.group_id
   product_id  = "prd_HTTP_Content_Del"
   hostnames {
     cname_from             = "test.edgesuite.net"

--- a/pkg/providers/papi/testdata/basic_with_both_activations/variables.tf
+++ b/pkg/providers/papi/testdata/basic_with_both_activations/variables.tf
@@ -7,3 +7,13 @@ variable "config_section" {
   type    = string
   default = "test_section"
 }
+
+variable "contract_id" {
+  type    = string
+  default = "test_contract"
+}
+
+variable "group_id" {
+  type    = string
+  default = "grp_12345"
+}

--- a/pkg/providers/papi/testdata/basic_with_cert_provisioning_type/property.tf
+++ b/pkg/providers/papi/testdata/basic_with_cert_provisioning_type/property.tf
@@ -27,8 +27,8 @@ data "akamai_property_rules_template" "rules" {
 }
 
 resource "akamai_edge_hostname" "test-edgesuite-net" {
-  contract_id   = data.akamai_contract.contract.id
-  group_id      = data.akamai_group.group.id
+  contract_id   = var.contract_id
+  group_id      = var.group_id
   ip_behavior   = "IPV6_COMPLIANCE"
   edge_hostname = "test.edgesuite.net"
   use_cases = jsonencode([
@@ -42,8 +42,8 @@ resource "akamai_edge_hostname" "test-edgesuite-net" {
 
 resource "akamai_property" "test-edgesuite-net" {
   name        = "test.edgesuite.net"
-  contract_id = data.akamai_contract.contract.id
-  group_id    = data.akamai_group.group.id
+  contract_id = var.contract_id
+  group_id    = var.group_id
   product_id  = "prd_HTTP_Content_Del"
   rule_format = "latest"
   hostnames {

--- a/pkg/providers/papi/testdata/basic_with_cert_provisioning_type/variables.tf
+++ b/pkg/providers/papi/testdata/basic_with_cert_provisioning_type/variables.tf
@@ -7,3 +7,13 @@ variable "config_section" {
   type    = string
   default = "test_section"
 }
+
+variable "contract_id" {
+  type    = string
+  default = "test_contract"
+}
+
+variable "group_id" {
+  type    = string
+  default = "grp_12345"
+}

--- a/pkg/providers/papi/testdata/basic_with_production_activation/property.tf
+++ b/pkg/providers/papi/testdata/basic_with_production_activation/property.tf
@@ -13,30 +13,21 @@ provider "akamai" {
   config_section = var.config_section
 }
 
-data "akamai_group" "group" {
-  group_name  = "test_group"
-  contract_id = "test_contract"
-}
-
-data "akamai_contract" "contract" {
-  group_name = data.akamai_group.group.group_name
-}
-
 data "akamai_property_rules_template" "rules" {
   template_file = abspath("${path.module}/property-snippets/main.json")
 }
 
 resource "akamai_edge_hostname" "test-edgesuite-net" {
-  contract_id   = data.akamai_contract.contract.id
-  group_id      = data.akamai_group.group.id
+  contract_id   = var.contract_id
+  group_id      = var.group_id
   ip_behavior   = "IPV6_COMPLIANCE"
   edge_hostname = "test.edgesuite.net"
 }
 
 resource "akamai_property" "test-edgesuite-net" {
   name        = "test.edgesuite.net"
-  contract_id = data.akamai_contract.contract.id
-  group_id    = data.akamai_group.group.id
+  contract_id = var.contract_id
+  group_id    = var.group_id
   product_id  = "prd_HTTP_Content_Del"
   hostnames {
     cname_from             = "test.edgesuite.net"

--- a/pkg/providers/papi/testdata/basic_with_production_activation/variables.tf
+++ b/pkg/providers/papi/testdata/basic_with_production_activation/variables.tf
@@ -7,3 +7,13 @@ variable "config_section" {
   type    = string
   default = "test_section"
 }
+
+variable "contract_id" {
+  type    = string
+  default = "test_contract"
+}
+
+variable "group_id" {
+  type    = string
+  default = "grp_12345"
+}

--- a/pkg/providers/papi/testdata/basic_with_use_cases/property.tf
+++ b/pkg/providers/papi/testdata/basic_with_use_cases/property.tf
@@ -13,22 +13,13 @@ provider "akamai" {
   config_section = var.config_section
 }
 
-data "akamai_group" "group" {
-  group_name  = "test_group"
-  contract_id = "test_contract"
-}
-
-data "akamai_contract" "contract" {
-  group_name = data.akamai_group.group.group_name
-}
-
 data "akamai_property_rules_template" "rules" {
   template_file = abspath("${path.module}/property-snippets/main.json")
 }
 
 resource "akamai_edge_hostname" "test-edgesuite-net" {
-  contract_id   = data.akamai_contract.contract.id
-  group_id      = data.akamai_group.group.id
+  contract_id   = var.contract_id
+  group_id      = var.group_id
   ip_behavior   = "IPV6_COMPLIANCE"
   edge_hostname = "test.edgesuite.net"
   use_cases = jsonencode([
@@ -42,8 +33,8 @@ resource "akamai_edge_hostname" "test-edgesuite-net" {
 
 resource "akamai_property" "test-edgesuite-net" {
   name        = "test.edgesuite.net"
-  contract_id = data.akamai_contract.contract.id
-  group_id    = data.akamai_group.group.id
+  contract_id = var.contract_id
+  group_id    = var.group_id
   product_id  = "prd_HTTP_Content_Del"
   hostnames {
     cname_from             = "test.edgesuite.net"

--- a/pkg/providers/papi/testdata/basic_with_use_cases/variables.tf
+++ b/pkg/providers/papi/testdata/basic_with_use_cases/variables.tf
@@ -7,3 +7,13 @@ variable "config_section" {
   type    = string
   default = "test_section"
 }
+
+variable "contract_id" {
+  type    = string
+  default = "test_contract"
+}
+
+variable "group_id" {
+  type    = string
+  default = "grp_12345"
+}

--- a/pkg/providers/papi/testdata/basic_without_activation/property.tf
+++ b/pkg/providers/papi/testdata/basic_without_activation/property.tf
@@ -13,30 +13,21 @@ provider "akamai" {
   config_section = var.config_section
 }
 
-data "akamai_group" "group" {
-  group_name  = "test_group"
-  contract_id = "test_contract"
-}
-
-data "akamai_contract" "contract" {
-  group_name = data.akamai_group.group.group_name
-}
-
 data "akamai_property_rules_template" "rules" {
   template_file = abspath("${path.module}/property-snippets/main.json")
 }
 
 resource "akamai_edge_hostname" "test-edgesuite-net" {
-  contract_id   = data.akamai_contract.contract.id
-  group_id      = data.akamai_group.group.id
+  contract_id   = var.contract_id
+  group_id      = var.group_id
   ip_behavior   = "IPV6_COMPLIANCE"
   edge_hostname = "test.edgesuite.net"
 }
 
 resource "akamai_property" "test-edgesuite-net" {
   name        = "test.edgesuite.net"
-  contract_id = data.akamai_contract.contract.id
-  group_id    = data.akamai_group.group.id
+  contract_id = var.contract_id
+  group_id    = var.group_id
   product_id  = "prd_HTTP_Content_Del"
   hostnames {
     cname_from             = "test.edgesuite.net"

--- a/pkg/providers/papi/testdata/basic_without_activation/variables.tf
+++ b/pkg/providers/papi/testdata/basic_without_activation/variables.tf
@@ -7,3 +7,13 @@ variable "config_section" {
   type    = string
   default = "test_section"
 }
+
+variable "contract_id" {
+  type    = string
+  default = "test_contract"
+}
+
+variable "group_id" {
+  type    = string
+  default = "grp_12345"
+}


### PR DESCRIPTION
## Version 1.9.0 (August 29, 2023)

### Features/Enhancements

* [IMPORTANT] CloudWrapper
  * Added support for `export-cloudwrapper` command which allows export of `akamai_cloudwrapper_configuration` and `akamai_cloudwrapper_activation` resources

* APPSEC
  * Added import support for custom client sequence

### Bug fixes

* Image and Video Manager
  * Added description for `--schema` flag for `export-imaging` command in `README.md` ([#56](https://github.com/akamai/cli-terraform/issues/56))

* PAPI
  * Fixed `export-property` command to export `akamai_property_activation` resource attributes for latest active version.
  * Fixed `export-property` command to use `group_id` and `contract_id` as terraform variables, instead of data sources, which
  produced inconsistencies ([I#374](https://github.com/akamai/terraform-provider-akamai/issues/426))
  * `logStreamName` field from `datastream` behavior has changed from string to array of strings for rule
    format `v2023-05-30` ([#58](https://github.com/akamai/cli-terraform/issues/58))
