### PR TITLE
Release/v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * CPS
   * Fixed nil pointer evaluating *cps.DNSNameSettings.CloneDNSNames ([#52](https://github.com/akamai/cli-terraform/issues/52))
 
+* Identity and Access Management (IAM)
+  * Fixed newline escaping in `description` field after exporting a role
+
 ## Version 1.9.0 (August 29, 2023)
 
 ### Features/Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## Version 1.10.0 (September xx, 2023)
+
+### Features/Enhancements
+
+### Bug fixes
+
+* CPS
+  * Fixed nil pointer evaluating *cps.DNSNameSettings.CloneDNSNames ([#52](https://github.com/akamai/cli-terraform/issues/52))
+
 ## Version 1.9.0 (August 29, 2023)
 
 ### Features/Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 * Identity and Access Management (IAM)
   * Fixed newline escaping in `description` field after exporting a role
 
+* PAPI
+  * Add missing fields to `akamai_property_builder` for `origin` and `siteShield` behaviors
+
 ## Version 1.9.0 (August 29, 2023)
 
 ### Features/Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Release Notes
 
-## Version 1.10.0 (September xx, 2023)
-
-### Features/Enhancements
+## Version 1.9.1 (September 26, 2023)
 
 ### Bug fixes
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ $(BIN)/tflint: $(BIN) ; $(info $(M) Installing tflint...)
 	curl -sSfL https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh  | bash
 
 GOLANGCILINT = $(BIN)/golangci-lint
-GOLANGCI_LINT_VERSION = v1.50.1
+GOLANGCI_LINT_VERSION = v1.52.2
 $(BIN)/golangci-lint: ; $(info $(M) Installing golangci-lint...)
 	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BIN) $(GOLANGCI_LINT_VERSION)
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.0-experimental
 # This script was copied from 'terraform-provider-akamai'
-FROM golang:1.18-alpine3.16
+FROM golang:1.20-alpine3.18
 ENV PROVIDER_VERSION="1.0.0" \
     GO111MODULE="on" \
     CGO_ENABLED=0 \

--- a/cli.json
+++ b/cli.json
@@ -5,7 +5,7 @@
   "commands": [
     {
       "name": "terraform",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "description": "Administer and Manage Akamai Terraform configurations",
       "bin": "https://github.com/akamai/cli-terraform/releases/download/v{{.Version}}/akamai-{{.Name}}-{{.Version}}-{{.OS}}{{.Arch}}{{.BinSuffix}}",
       "auto-complete": true,

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -33,7 +33,7 @@ import (
 
 var (
 	// Version holds current version of cli-terraform
-	Version = "1.9.0"
+	Version = "1.9.1"
 )
 
 // Run initializes the cli and runs it

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/akamai/cli-terraform
 go 1.18
 
 require (
-	github.com/akamai/AkamaiOPEN-edgegrid-golang/v7 v7.2.0
+	github.com/akamai/AkamaiOPEN-edgegrid-golang/v7 v7.2.1
 	github.com/akamai/cli v1.5.5
 	github.com/fatih/color v1.13.0
 	github.com/hashicorp/hcl/v2 v2.11.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/akamai/cli-terraform
 go 1.18
 
 require (
-	github.com/akamai/AkamaiOPEN-edgegrid-golang/v7 v7.2.1
+	github.com/akamai/AkamaiOPEN-edgegrid-golang/v7 v7.3.0
 	github.com/akamai/cli v1.5.5
 	github.com/fatih/color v1.13.0
 	github.com/hashicorp/hcl/v2 v2.11.1

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/akamai/cli v1.5.5
 	github.com/fatih/color v1.13.0
 	github.com/hashicorp/hcl/v2 v2.11.1
+	github.com/jinzhu/copier v0.4.0
 	github.com/shirou/gopsutil v2.20.4+incompatible
 	github.com/stretchr/testify v1.8.0
 	github.com/tj/assert v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDO
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/akamai/AkamaiOPEN-edgegrid-golang/v7 v7.2.0 h1:sGkT91nSXjHU/s+ItP+kTgea1WCfpgAWwx+snxlP/+E=
-github.com/akamai/AkamaiOPEN-edgegrid-golang/v7 v7.2.0/go.mod h1:zZWAMUwE4q5sVPgnjz9jiqtXA01tM3m9HYd6Wk0ev90=
+github.com/akamai/AkamaiOPEN-edgegrid-golang/v7 v7.2.1 h1:amPKOiXDgUXQcSMMg0XXvOZkF9sQcffZXZrZT4VJ3z0=
+github.com/akamai/AkamaiOPEN-edgegrid-golang/v7 v7.2.1/go.mod h1:zZWAMUwE4q5sVPgnjz9jiqtXA01tM3m9HYd6Wk0ev90=
 github.com/akamai/cli v1.5.5 h1:XKubVW8WOVP8qcgJRK2MOj8HeqC4kudvSOM0m8mJsj0=
 github.com/akamai/cli v1.5.5/go.mod h1:29wClp63PEEkpDLxtqM/JrVmnwOCSaE+itIJjCAIECE=
 github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 h1:MzBOUgng9orim59UnfUTLRjMpd09C5uEVQ6RPGeCaVI=

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDO
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/akamai/AkamaiOPEN-edgegrid-golang/v7 v7.2.1 h1:amPKOiXDgUXQcSMMg0XXvOZkF9sQcffZXZrZT4VJ3z0=
-github.com/akamai/AkamaiOPEN-edgegrid-golang/v7 v7.2.1/go.mod h1:zZWAMUwE4q5sVPgnjz9jiqtXA01tM3m9HYd6Wk0ev90=
+github.com/akamai/AkamaiOPEN-edgegrid-golang/v7 v7.3.0 h1:eiPKdmGPXJCfnavOVhJ2vNDHwNilLzdXfn/CqnPmfZ4=
+github.com/akamai/AkamaiOPEN-edgegrid-golang/v7 v7.3.0/go.mod h1:+8Nc6CkB/hiTEvoxxZwvY3whU5QsXxW4RhSARTMnAfI=
 github.com/akamai/cli v1.5.5 h1:XKubVW8WOVP8qcgJRK2MOj8HeqC4kudvSOM0m8mJsj0=
 github.com/akamai/cli v1.5.5/go.mod h1:29wClp63PEEkpDLxtqM/JrVmnwOCSaE+itIJjCAIECE=
 github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 h1:MzBOUgng9orim59UnfUTLRjMpd09C5uEVQ6RPGeCaVI=

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/hashicorp/hcl/v2 v2.11.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oay
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/jinzhu/copier v0.4.0 h1:w3ciUoD19shMCRargcpm0cm91ytaBhDvuRpz1ODO/U8=
+github.com/jinzhu/copier v0.4.0/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7/go.mod h1:2iMrUgbbvHEiQClaW2NsSzMyGHqN+rDFqY705q49KG0=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=

--- a/pkg/providers/cps/create_cps_test.go
+++ b/pkg/providers/cps/create_cps_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v7/pkg/tools"
 	"github.com/akamai/cli-terraform/pkg/templates"
 	"github.com/akamai/cli/pkg/terminal"
+	"github.com/jinzhu/copier"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -485,6 +486,18 @@ func TestCreateCPS(t *testing.T) {
 		"export DV enrollment with minimum fields": {
 			init: func(m *cps.Mock) {
 				expectGetEnrollment(m, 1, enrollmentDVMin, nil).Once()
+			},
+			enrollmentID: 1,
+			contractID:   "ctr_1",
+			dataDir:      "dv_enrollment_min",
+			filesToCheck: []string{"enrollment.tf", "import.sh", "variables.tf"},
+		},
+		"export DV enrollment without DNSNameSettings": {
+			init: func(m *cps.Mock) {
+				var enrollment cps.Enrollment
+				_ = copier.CopyWithOption(&enrollment, enrollmentDVMin, copier.Option{DeepCopy: true})
+				enrollment.NetworkConfiguration.DNSNameSettings = nil
+				expectGetEnrollment(m, 1, enrollment, nil).Once()
 			},
 			enrollmentID: 1,
 			contractID:   "ctr_1",

--- a/pkg/providers/cps/templates/enrollment.tmpl
+++ b/pkg/providers/cps/templates/enrollment.tmpl
@@ -94,7 +94,7 @@ provider "akamai" {
         {{- if .DisallowedTLSVersions}}
             disallowed_tls_versions = [{{range .DisallowedTLSVersions}}"{{.}}",{{end}}]
         {{- end}}
-        {{- if .DNSNameSettings.CloneDNSNames}}
+        {{- if and .DNSNameSettings .DNSNameSettings.CloneDNSNames}}
             clone_dns_names         = {{.DNSNameSettings.CloneDNSNames}}
         {{- end}}
         geography               = "{{.Geography}}"

--- a/pkg/providers/iam/create_iam_role_test.go
+++ b/pkg/providers/iam/create_iam_role_test.go
@@ -432,7 +432,7 @@ func TestProcessIAMRoleTemplates(t *testing.T) {
 					{
 						RoleID:          12345,
 						RoleName:        "Custom role",
-						RoleDescription: "Custom role description",
+						RoleDescription: "Custom role\ndescription",
 						GrantedRoles:    []int{992, 707, 452, 677, 726, 296, 457, 987},
 					},
 				},

--- a/pkg/providers/iam/templates/roles.tmpl
+++ b/pkg/providers/iam/templates/roles.tmpl
@@ -6,7 +6,7 @@
 {{- range .TFRoles -}}
     resource "akamai_iam_role" "role_id_{{.RoleID}}" {
       name          = "{{.RoleName}}"
-      description   = "{{.RoleDescription}}"
+      description   = "{{escape .RoleDescription}}"
       granted_roles = {{formatIntList .GrantedRoles}}
     }
 

--- a/pkg/providers/iam/testdata/iam_role_by_id_basic/role.tf
+++ b/pkg/providers/iam/testdata/iam_role_by_id_basic/role.tf
@@ -15,7 +15,7 @@ provider "akamai" {
 
 resource "akamai_iam_role" "role_id_12345" {
   name          = "Custom role"
-  description   = "Custom role description"
+  description   = "Custom role\ndescription"
   granted_roles = [992, 707, 452, 677, 726, 296, 457, 987]
 }
 

--- a/pkg/providers/papi/templates/includes.tmpl
+++ b/pkg/providers/papi/templates/includes.tmpl
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 3.2.0"
+      version = ">= 5.3.0"
     }
   }
   required_version = ">= 0.13"

--- a/pkg/providers/papi/templates/property.tmpl
+++ b/pkg/providers/papi/templates/property.tmpl
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 5.0.0"
+      version = ">= 5.3.0"
     }
   }
   required_version = ">= 0.13"

--- a/pkg/providers/papi/templates/rules_v2023-01-05.tmpl
+++ b/pkg/providers/papi/templates/rules_v2023-01-05.tmpl
@@ -5439,11 +5439,90 @@ origin {
 		{{- range $v := $v}}
 		custom_certificate_authorities {
 {{- range $k, $v := $v}}
-{{- if and (eq $k "pemEncodedCert") (ne $v nil)}}
-        pem_encoded_cert = {{template "Text" $v}}
+{{- if and (eq $k "subjectCN") (ne $v nil)}}
+        subject_cn = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "subjectAlternativeNames"}}
+		subject_alternative_names = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "subjectRDNs" }}
+		{{- if $v}}
+		subject_rdns {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "C") (ne $v nil)}}
+        c = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "OU") (ne $v nil)}}
+        ou = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "O") (ne $v nil)}}
+        o = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "CN") (ne $v nil)}}
+        cn = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if eq $k "issuerRDNs" }}
+		{{- if $v}}
+		issuer_rdns {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "C") (ne $v nil)}}
+        c = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "OU") (ne $v nil)}}
+        ou = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "O") (ne $v nil)}}
+        o = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "CN") (ne $v nil)}}
+        cn = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "notBefore") (ne $v nil)}}
+		not_before = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "notAfter") (ne $v nil)}}
+		not_after = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "sigAlgName") (ne $v nil)}}
+        sig_alg_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "publicKey") (ne $v nil)}}
+        public_key = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "publicKeyAlgorithm") (ne $v nil)}}
+        public_key_algorithm = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "publicKeyFormat") (ne $v nil)}}
+        public_key_format = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "serialNumber") (ne $v nil)}}
+        serial_number = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "version") (ne $v nil)}}
+		version = {{$v | AsInt}}
 {{- end}}
 {{- if and (eq $k "sha1Fingerprint") (ne $v nil)}}
         sha1_fingerprint = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "pemEncodedCert") (ne $v nil)}}
+        pem_encoded_cert = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "canBeLeaf") (ne $v nil)}}
+		can_be_leaf = {{$v}}
+{{- end}}
+{{- if and (eq $k "canBeCA") (ne $v nil)}}
+		can_be_ca = {{$v}}
+{{- end}}
+{{- if and (eq $k "selfSigned") (ne $v nil)}}
+		self_signed = {{$v}}
 {{- end}}
 {{- end}}
 		}
@@ -5453,11 +5532,90 @@ origin {
 		{{- range $v := $v}}
 		custom_certificates {
 {{- range $k, $v := $v}}
-{{- if and (eq $k "pemEncodedCert") (ne $v nil)}}
-        pem_encoded_cert = {{template "Text" $v}}
+{{- if and (eq $k "subjectCN") (ne $v nil)}}
+        subject_cn = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "subjectAlternativeNames"}}
+		subject_alternative_names = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "subjectRDNs" }}
+		{{- if $v}}
+		subject_rdns {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "C") (ne $v nil)}}
+        c = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "OU") (ne $v nil)}}
+        ou = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "O") (ne $v nil)}}
+        o = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "CN") (ne $v nil)}}
+        cn = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if eq $k "issuerRDNs" }}
+		{{- if $v}}
+		issuer_rdns {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "C") (ne $v nil)}}
+        c = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "OU") (ne $v nil)}}
+        ou = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "O") (ne $v nil)}}
+        o = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "CN") (ne $v nil)}}
+        cn = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "notBefore") (ne $v nil)}}
+		not_before = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "notAfter") (ne $v nil)}}
+		not_after = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "sigAlgName") (ne $v nil)}}
+        sig_alg_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "publicKey") (ne $v nil)}}
+        public_key = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "publicKeyAlgorithm") (ne $v nil)}}
+        public_key_algorithm = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "publicKeyFormat") (ne $v nil)}}
+        public_key_format = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "serialNumber") (ne $v nil)}}
+        serial_number = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "version") (ne $v nil)}}
+		version = {{$v | AsInt}}
 {{- end}}
 {{- if and (eq $k "sha1Fingerprint") (ne $v nil)}}
         sha1_fingerprint = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "pemEncodedCert") (ne $v nil)}}
+        pem_encoded_cert = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "canBeLeaf") (ne $v nil)}}
+		can_be_leaf = {{$v}}
+{{- end}}
+{{- if and (eq $k "canBeCA") (ne $v nil)}}
+		can_be_ca = {{$v}}
+{{- end}}
+{{- if and (eq $k "selfSigned") (ne $v nil)}}
+		self_signed = {{$v}}
 {{- end}}
 {{- end}}
 		}
@@ -7255,6 +7413,15 @@ site_shield {
 {{- end}}
 {{- if and (eq $k "srmap") (ne $v nil)}}
         srmap = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "chinaCdnMap") (ne $v nil)}}
+        china_cdn_map = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "hasMixedHosts") (ne $v nil)}}
+		has_mixed_hosts = {{$v}}
+{{- end}}
+{{- if and (eq $k "src") (ne $v nil)}}
+        src = {{template "Text" $v}}
 {{- end}}
 {{- end}}
 		}

--- a/pkg/providers/papi/templates/rules_v2023-05-30.tmpl
+++ b/pkg/providers/papi/templates/rules_v2023-05-30.tmpl
@@ -5325,11 +5325,90 @@ origin {
 		{{- range $v := $v}}
 		custom_certificate_authorities {
 {{- range $k, $v := $v}}
-{{- if and (eq $k "pemEncodedCert") (ne $v nil)}}
-        pem_encoded_cert = {{template "Text" $v}}
+{{- if and (eq $k "subjectCN") (ne $v nil)}}
+        subject_cn = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "subjectAlternativeNames"}}
+		subject_alternative_names = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "subjectRDNs" }}
+		{{- if $v}}
+		subject_rdns {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "C") (ne $v nil)}}
+        c = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "OU") (ne $v nil)}}
+        ou = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "O") (ne $v nil)}}
+        o = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "CN") (ne $v nil)}}
+        cn = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if eq $k "issuerRDNs" }}
+		{{- if $v}}
+		issuer_rdns {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "C") (ne $v nil)}}
+        c = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "OU") (ne $v nil)}}
+        ou = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "O") (ne $v nil)}}
+        o = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "CN") (ne $v nil)}}
+        cn = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "notBefore") (ne $v nil)}}
+		not_before = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "notAfter") (ne $v nil)}}
+		not_after = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "sigAlgName") (ne $v nil)}}
+        sig_alg_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "publicKey") (ne $v nil)}}
+        public_key = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "publicKeyAlgorithm") (ne $v nil)}}
+        public_key_algorithm = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "publicKeyFormat") (ne $v nil)}}
+        public_key_format = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "serialNumber") (ne $v nil)}}
+        serial_number = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "version") (ne $v nil)}}
+		version = {{$v | AsInt}}
 {{- end}}
 {{- if and (eq $k "sha1Fingerprint") (ne $v nil)}}
         sha1_fingerprint = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "pemEncodedCert") (ne $v nil)}}
+        pem_encoded_cert = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "canBeLeaf") (ne $v nil)}}
+		can_be_leaf = {{$v}}
+{{- end}}
+{{- if and (eq $k "canBeCA") (ne $v nil)}}
+		can_be_ca = {{$v}}
+{{- end}}
+{{- if and (eq $k "selfSigned") (ne $v nil)}}
+		self_signed = {{$v}}
 {{- end}}
 {{- end}}
 		}
@@ -5339,11 +5418,90 @@ origin {
 		{{- range $v := $v}}
 		custom_certificates {
 {{- range $k, $v := $v}}
-{{- if and (eq $k "pemEncodedCert") (ne $v nil)}}
-        pem_encoded_cert = {{template "Text" $v}}
+{{- if and (eq $k "subjectCN") (ne $v nil)}}
+        subject_cn = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "subjectAlternativeNames"}}
+		subject_alternative_names = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "subjectRDNs" }}
+		{{- if $v}}
+		subject_rdns {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "C") (ne $v nil)}}
+        c = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "OU") (ne $v nil)}}
+        ou = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "O") (ne $v nil)}}
+        o = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "CN") (ne $v nil)}}
+        cn = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if eq $k "issuerRDNs" }}
+		{{- if $v}}
+		issuer_rdns {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "C") (ne $v nil)}}
+        c = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "OU") (ne $v nil)}}
+        ou = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "O") (ne $v nil)}}
+        o = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "CN") (ne $v nil)}}
+        cn = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "notBefore") (ne $v nil)}}
+		not_before = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "notAfter") (ne $v nil)}}
+		not_after = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "sigAlgName") (ne $v nil)}}
+        sig_alg_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "publicKey") (ne $v nil)}}
+        public_key = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "publicKeyAlgorithm") (ne $v nil)}}
+        public_key_algorithm = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "publicKeyFormat") (ne $v nil)}}
+        public_key_format = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "serialNumber") (ne $v nil)}}
+        serial_number = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "version") (ne $v nil)}}
+		version = {{$v | AsInt}}
 {{- end}}
 {{- if and (eq $k "sha1Fingerprint") (ne $v nil)}}
         sha1_fingerprint = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "pemEncodedCert") (ne $v nil)}}
+        pem_encoded_cert = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "canBeLeaf") (ne $v nil)}}
+		can_be_leaf = {{$v}}
+{{- end}}
+{{- if and (eq $k "canBeCA") (ne $v nil)}}
+		can_be_ca = {{$v}}
+{{- end}}
+{{- if and (eq $k "selfSigned") (ne $v nil)}}
+		self_signed = {{$v}}
 {{- end}}
 {{- end}}
 		}
@@ -7152,6 +7310,15 @@ site_shield {
 {{- end}}
 {{- if and (eq $k "srmap") (ne $v nil)}}
         srmap = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "chinaCdnMap") (ne $v nil)}}
+        china_cdn_map = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "hasMixedHosts") (ne $v nil)}}
+		has_mixed_hosts = {{$v}}
+{{- end}}
+{{- if and (eq $k "src") (ne $v nil)}}
+        src = {{template "Text" $v}}
 {{- end}}
 {{- end}}
 		}

--- a/pkg/providers/papi/testdata/basic-rules-datasource-schema1/property.tf
+++ b/pkg/providers/papi/testdata/basic-rules-datasource-schema1/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 5.0.0"
+      version = ">= 5.3.0"
     }
   }
   required_version = ">= 0.13"

--- a/pkg/providers/papi/testdata/basic-rules-datasource-schema2/property.tf
+++ b/pkg/providers/papi/testdata/basic-rules-datasource-schema2/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 5.0.0"
+      version = ">= 5.3.0"
     }
   }
   required_version = ">= 0.13"

--- a/pkg/providers/papi/testdata/basic-rules-datasource/property.tf
+++ b/pkg/providers/papi/testdata/basic-rules-datasource/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 5.0.0"
+      version = ">= 5.3.0"
     }
   }
   required_version = ">= 0.13"

--- a/pkg/providers/papi/testdata/basic-v1/property.tf
+++ b/pkg/providers/papi/testdata/basic-v1/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 5.0.0"
+      version = ">= 5.3.0"
     }
   }
   required_version = ">= 0.13"

--- a/pkg/providers/papi/testdata/basic/property.tf
+++ b/pkg/providers/papi/testdata/basic/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 5.0.0"
+      version = ">= 5.3.0"
     }
   }
   required_version = ">= 0.13"

--- a/pkg/providers/papi/testdata/basic_property_with_empty_hostname_id/property.tf
+++ b/pkg/providers/papi/testdata/basic_property_with_empty_hostname_id/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 5.0.0"
+      version = ">= 5.3.0"
     }
   }
   required_version = ">= 0.13"

--- a/pkg/providers/papi/testdata/basic_property_with_include/property.tf
+++ b/pkg/providers/papi/testdata/basic_property_with_include/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 5.0.0"
+      version = ">= 5.3.0"
     }
   }
   required_version = ">= 0.13"

--- a/pkg/providers/papi/testdata/basic_property_with_multiple_includes/property.tf
+++ b/pkg/providers/papi/testdata/basic_property_with_multiple_includes/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 5.0.0"
+      version = ">= 5.3.0"
     }
   }
   required_version = ">= 0.13"

--- a/pkg/providers/papi/testdata/basic_property_with_multiple_includes_schema/property.tf
+++ b/pkg/providers/papi/testdata/basic_property_with_multiple_includes_schema/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 5.0.0"
+      version = ">= 5.3.0"
     }
   }
   required_version = ">= 0.13"

--- a/pkg/providers/papi/testdata/basic_with_activation_note/property.tf
+++ b/pkg/providers/papi/testdata/basic_with_activation_note/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 5.0.0"
+      version = ">= 5.3.0"
     }
   }
   required_version = ">= 0.13"

--- a/pkg/providers/papi/testdata/basic_with_both_activations/property.tf
+++ b/pkg/providers/papi/testdata/basic_with_both_activations/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 5.0.0"
+      version = ">= 5.3.0"
     }
   }
   required_version = ">= 0.13"

--- a/pkg/providers/papi/testdata/basic_with_cert_provisioning_type/property.tf
+++ b/pkg/providers/papi/testdata/basic_with_cert_provisioning_type/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 5.0.0"
+      version = ">= 5.3.0"
     }
   }
   required_version = ">= 0.13"

--- a/pkg/providers/papi/testdata/basic_with_production_activation/property.tf
+++ b/pkg/providers/papi/testdata/basic_with_production_activation/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 5.0.0"
+      version = ">= 5.3.0"
     }
   }
   required_version = ">= 0.13"

--- a/pkg/providers/papi/testdata/basic_with_use_cases/property.tf
+++ b/pkg/providers/papi/testdata/basic_with_use_cases/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 5.0.0"
+      version = ">= 5.3.0"
     }
   }
   required_version = ">= 0.13"

--- a/pkg/providers/papi/testdata/basic_without_activation/property.tf
+++ b/pkg/providers/papi/testdata/basic_without_activation/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 5.0.0"
+      version = ">= 5.3.0"
     }
   }
   required_version = ">= 0.13"

--- a/pkg/providers/papi/testdata/include_basic/includes.tf
+++ b/pkg/providers/papi/testdata/include_basic/includes.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 3.2.0"
+      version = ">= 5.3.0"
     }
   }
   required_version = ">= 0.13"

--- a/pkg/providers/papi/testdata/include_basic_schema/includes.tf
+++ b/pkg/providers/papi/testdata/include_basic_schema/includes.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 3.2.0"
+      version = ">= 5.3.0"
     }
   }
   required_version = ">= 0.13"

--- a/pkg/providers/papi/testdata/include_no_network/includes.tf
+++ b/pkg/providers/papi/testdata/include_no_network/includes.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 3.2.0"
+      version = ">= 5.3.0"
     }
   }
   required_version = ">= 0.13"

--- a/pkg/providers/papi/testdata/include_single_network/includes.tf
+++ b/pkg/providers/papi/testdata/include_single_network/includes.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 3.2.0"
+      version = ">= 5.3.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
## Version 1.9.1 (September 26, 2023)

### Bug fixes

* CPS
  * Fixed nil pointer evaluating *cps.DNSNameSettings.CloneDNSNames ([#52](https://github.com/akamai/cli-terraform/issues/52))

* Identity and Access Management (IAM)
  * Fixed newline escaping in `description` field after exporting a role

* PAPI
  * Add missing fields to `akamai_property_builder` for `origin` and `siteShield` behaviors