### PR TITLE
DXISSUE-2896 Fix README.md code notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Certain export conditions require the use of a particular property rule format. 
   <tr>
     <td>Addition of <code>--schema</code> flag</td>
     <td>Your declarative property configuration and HCL-formatted rules. <strong>Does not return includes</strong> as includes are JSON-formatted.</td>
-    <td>Must be a dated rule format ≥ <code>v2023-01-05</code>. Cannot use `latest`.</td>
+    <td>Must be a dated rule format ≥ <code>v2023-01-05</code>. Cannot use <code>latest</code>.</td>
   </tr>
   <tr>
     <td>Addition of <code>include</code> subcommand</td>


### PR DESCRIPTION
**Issue**
README.md table for property is in html. Recent update used Markdown instead of HTML syntax. Code item not rendering properly.

**Solution**
Removed Markdown ticks and replaced with `<code>` tags.

**Test**
Preview pane of changes showed render is correct.

