### PR TITLE
DXE-3895 Release/v1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 
 
+* [IMPORTANT] Cloud Access Manager
+  * Added command `export-cloudaccess` which allows export of `akamai_cloudaccess_key` resource
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Version X.XX.X (Month XX, XXXX)
 
 ### Features/Enhancements
-
+* Migrated go version to 1.21.12 for builds.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
 
 
 
-
+* PAPI
+  * If edgehostname uses custom TTL, it is exported in the `akamai_edge_hostname` resource 
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@
 
 
 
+* PAPI 
+  * Added support for new rule format `v2024-05-31`
+
+
+
+
+
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,98 +1,16 @@
 # Release Notes
 
-## Version X.XX.X (Month XX, XXXX)
+## Version 1.16.0 (July 16, 2024)
 
 ### Features/Enhancements
 * Migrated go version to 1.21.12 for builds.
 
-
-
-
-
-
-
 * [IMPORTANT] Cloud Access Manager
   * Added command `export-cloudaccess` which allows export of `akamai_cloudaccess_key` resource
 
-
-
 * PAPI
-  * If edgehostname uses custom TTL, it is exported in the `akamai_edge_hostname` resource 
-
-
-
-
-
-
-
-
-
-
-* PAPI 
+  * If edgehostname uses custom TTL, it is exported in the `akamai_edge_hostname` resource
   * Added support for new rule format `v2024-05-31`
-
-
-
-
-
-
-
-
-
-
-
-
-
-### Bug fixes
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-### Deprecations
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 ## Version 1.15.0 (May 28, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,89 @@
 # Release Notes
 
+## Version X.XX.X (Month XX, XXXX)
+
+### Features/Enhancements
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+### Bug fixes
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+### Deprecations
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 ## Version 1.15.0 (May 28, 2024)
 
 ### Features/Enhancements

--- a/README.md
+++ b/README.md
@@ -400,8 +400,6 @@ Flags:
 
 Flags:
    --tfworkpath path         Directory used to store files created when running commands. (default: current directory)
-   --policy-json-dir path    Path location for placement of policy jsons. Default: same value as tfworkpath
-   --policy-as-hcl           Generate content of the policy using HCL instead of JSON file (default: false)
 ```
 
 ## General Notes

--- a/README.md
+++ b/README.md
@@ -382,13 +382,26 @@ $ akamai terraform export-cps
 
 ## Client Lists
 
-Export Client List.
+### Export Client List.
 
 ```
 akamai terraform [global flags] export-clientlist [flags] <list_id>
 
 Flags:
    --tfworkpath path      Directory used to store files created when running commands. (default: current directory)
+```
+
+## Cloud Access Manager
+
+### Export Cloud Access key configuration
+
+```
+   akamai terraform [global flags] export-cloudaccess [flags] <cloud_access_key_uid>
+
+Flags:
+   --tfworkpath path         Directory used to store files created when running commands. (default: current directory)
+   --policy-json-dir path    Path location for placement of policy jsons. Default: same value as tfworkpath
+   --policy-as-hcl           Generate content of the policy using HCL instead of JSON file (default: false)
 ```
 
 ## General Notes

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.0-experimental
 # This script was copied from 'terraform-provider-akamai'
-FROM golang:1.21-alpine3.18
+FROM golang:1.21.12-alpine3.20
 ENV PROVIDER_VERSION="1.0.0" \
     GO111MODULE="on" \
     CGO_ENABLED=0 \

--- a/cli.json
+++ b/cli.json
@@ -5,7 +5,7 @@
   "commands": [
     {
       "name": "terraform",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "description": "Administer and Manage Akamai Terraform configurations",
       "bin": "https://github.com/akamai/cli-terraform/releases/download/v{{.Version}}/akamai-{{.Name}}-{{.Version}}-{{.OS}}{{.Arch}}{{.BinSuffix}}",
       "auto-complete": true,

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -33,7 +33,7 @@ import (
 
 var (
 	// Version holds current version of cli-terraform
-	Version = "1.15.0"
+	Version = "1.16.0"
 )
 
 // Run initializes the cli and runs it

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/akamai/cli-terraform
 go 1.21
 
 require (
-	github.com/akamai/AkamaiOPEN-edgegrid-golang/v8 v8.2.0
+	github.com/akamai/AkamaiOPEN-edgegrid-golang/v8 v8.3.0
 	github.com/akamai/cli v1.5.6
 	github.com/fatih/color v1.13.0
 	github.com/hashicorp/hcl/v2 v2.11.1

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDO
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/akamai/AkamaiOPEN-edgegrid-golang/v8 v8.2.0 h1:aN4wkKx/Wu2zk6iM1yYXSI5Pu/6dzvUvleUUZojsp5E=
-github.com/akamai/AkamaiOPEN-edgegrid-golang/v8 v8.2.0/go.mod h1:2xRRnHx8dnw0i8IZPYOI0I7xbr1gnAN1uIYo7acMIbg=
+github.com/akamai/AkamaiOPEN-edgegrid-golang/v8 v8.3.0 h1:hB9ddRrmjfrxchN4NWABj3eT5PtkBAFRkxe5eqwBB7k=
+github.com/akamai/AkamaiOPEN-edgegrid-golang/v8 v8.3.0/go.mod h1:8hi/1Ctc9KGtPSZhpMRDRGULSvXpnce4htof1pH2wvI=
 github.com/akamai/cli v1.5.6 h1:L/QsSqligFRhMD+tKJoX9cwqbHnmojfqXw64HUfp6gk=
 github.com/akamai/cli v1.5.6/go.mod h1:PwHrS8f2vh1Kns2Hl1rtfMCq90ZfYLXI81zRGDTkMRs=
 github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 h1:MzBOUgng9orim59UnfUTLRjMpd09C5uEVQ6RPGeCaVI=
@@ -77,9 +77,8 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
-github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3vkb4ax0b5D2DHbNAUsen0Gx5wZoq3lV4=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -355,13 +355,6 @@ func CommandLocator() ([]*cli.Command, error) {
 	})
 
 	commands = append(commands, &cli.Command{
-		Name:               "list",
-		Description:        "List commands",
-		Action:             cmdList,
-		CustomHelpTemplate: apphelp.SimplifiedHelpTemplate,
-	})
-
-	commands = append(commands, &cli.Command{
 		Name:        "export-cloudaccess",
 		Description: "Generates Terraform configuration for CAM (Cloud Access Manager) resources",
 		Usage:       "export-cloudaccess",

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -18,6 +18,7 @@ package commands
 import (
 	"github.com/akamai/cli-terraform/pkg/providers/appsec"
 	"github.com/akamai/cli-terraform/pkg/providers/clientlists"
+	"github.com/akamai/cli-terraform/pkg/providers/cloudaccess"
 	"github.com/akamai/cli-terraform/pkg/providers/cloudlets"
 	"github.com/akamai/cli-terraform/pkg/providers/cloudwrapper"
 	"github.com/akamai/cli-terraform/pkg/providers/cps"
@@ -343,6 +344,29 @@ func CommandLocator() ([]*cli.Command, error) {
 		Usage:       "export-cps",
 		ArgsUsage:   "<enrollment_id> <contract_id>",
 		Action:      validatedAction(cps.CmdCreateCPS, requireValidWorkpath, requireNArguments(2)),
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:        "tfworkpath",
+				Usage:       "Directory used to store files created when running commands.",
+				DefaultText: "current directory",
+			},
+		},
+		BashComplete: autocomplete.Default,
+	})
+
+	commands = append(commands, &cli.Command{
+		Name:               "list",
+		Description:        "List commands",
+		Action:             cmdList,
+		CustomHelpTemplate: apphelp.SimplifiedHelpTemplate,
+	})
+
+	commands = append(commands, &cli.Command{
+		Name:        "export-cloudaccess",
+		Description: "Generates Terraform configuration for CAM (Cloud Access Manager) resources",
+		Usage:       "export-cloudaccess",
+		ArgsUsage:   "<access_key_uid>",
+		Action:      validatedAction(cloudaccess.CmdCreateCloudAccess, requireValidWorkpath, requireNArguments(1)),
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:        "tfworkpath",

--- a/pkg/providers/cloudaccess/create_key.go
+++ b/pkg/providers/cloudaccess/create_key.go
@@ -1,0 +1,196 @@
+// Package cloudaccess contains code for exporting CloudAccess key
+package cloudaccess
+
+import (
+	"context"
+	"embed"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v8/pkg/cloudaccess"
+	"github.com/akamai/cli-terraform/pkg/edgegrid"
+	"github.com/akamai/cli-terraform/pkg/templates"
+	"github.com/akamai/cli-terraform/pkg/tools"
+	"github.com/akamai/cli/pkg/terminal"
+	"github.com/fatih/color"
+	"github.com/urfave/cli/v2"
+)
+
+type (
+	// TFCloudAccessData represents the data used in CloudAccess
+	TFCloudAccessData struct {
+		Key     TFCloudAccessKey
+		Section string
+	}
+
+	// TFCloudAccessKey represents the data used for export CloudAccess key
+	TFCloudAccessKey struct {
+		KeyResourceName      string
+		AccessKeyName        string
+		AuthenticationMethod string
+		GroupID              int64
+		ContractID           string
+		AccessKeyUID         int64
+		CredentialA          *Credential
+		CredentialB          *Credential
+		NetworkConfiguration *NetworkConfiguration
+	}
+
+	// Credential represents CLoudAccess credential
+	Credential struct {
+		CloudAccessKeyID string
+	}
+
+	// NetworkConfiguration represents CLoudAccess network configuration
+	NetworkConfiguration struct {
+		AdditionalCDN   string
+		SecurityNetwork string
+	}
+)
+
+var (
+	//go:embed templates/*
+	templateFiles embed.FS
+
+	additionalFunctions = tools.DecorateWithMultilineHandlingFunctions(map[string]any{})
+
+	// ErrFetchingKey is returned when key could not be fetched
+	ErrFetchingKey = errors.New("problem with fetching key")
+	// ErrListingKeyVersions is returned when key versions could not be listed
+	ErrListingKeyVersions = errors.New("problem with listing key versions")
+	// ErrSavingFiles is returned when an issue with processing templates occurs
+	ErrSavingFiles = errors.New("saving terraform project files")
+	// ErrNoGroup is returned when key does not have group and contract assigned
+	ErrNoGroup = errors.New("access key has no defined group or contract")
+)
+
+// CmdCreateCloudAccess is an entrypoint to export-cloudaccess command
+func CmdCreateCloudAccess(c *cli.Context) error {
+	ctx := c.Context
+	sess := edgegrid.GetSession(ctx)
+	client := cloudaccess.Client(sess)
+
+	// tfWorkPath is a target directory for generated terraform resources
+	var tfWorkPath = "./"
+	if c.IsSet("tfworkpath") {
+		tfWorkPath = c.String("tfworkpath")
+	}
+	cloudAccessPath := filepath.Join(tfWorkPath, "cloudaccess.tf")
+	variablesPath := filepath.Join(tfWorkPath, "variables.tf")
+	importPath := filepath.Join(tfWorkPath, "import.sh")
+	if err := tools.CheckFiles(cloudAccessPath, variablesPath, importPath); err != nil {
+		return cli.Exit(color.RedString(err.Error()), 1)
+	}
+
+	templateToFile := map[string]string{
+		"cloudaccess.tmpl": cloudAccessPath,
+		"variables.tmpl":   variablesPath,
+		"imports.tmpl":     importPath,
+	}
+
+	processor := templates.FSTemplateProcessor{
+		TemplatesFS:     templateFiles,
+		TemplateTargets: templateToFile,
+		AdditionalFuncs: additionalFunctions,
+	}
+
+	keyUID, err := strconv.ParseInt(c.Args().Get(0), 10, 64)
+	if err != nil {
+		return cli.Exit(color.RedString(err.Error()), 1)
+	}
+	section := edgegrid.GetEdgercSection(c)
+	if err = createCloudAccess(ctx, keyUID, section, client, processor); err != nil {
+		return cli.Exit(color.RedString(fmt.Sprintf("Error exporting cloudaccess: %s", err)), 1)
+	}
+	return nil
+}
+
+func createCloudAccess(ctx context.Context, accessKeyUID int64, section string, client cloudaccess.CloudAccess, templateProcessor templates.TemplateProcessor) error {
+	term := terminal.Get(ctx)
+	term.Spinner().Start("Fetching cloudaccess key " + strconv.Itoa(int(accessKeyUID)))
+	key, err := client.GetAccessKey(ctx, cloudaccess.AccessKeyRequest{
+		AccessKeyUID: accessKeyUID,
+	})
+	if err != nil {
+		term.Spinner().Fail()
+		return fmt.Errorf("%w: %s", ErrFetchingKey, err)
+	}
+
+	if len(key.Groups) == 0 {
+		return ErrNoGroup
+	}
+
+	versions, err := client.ListAccessKeyVersions(ctx, cloudaccess.ListAccessKeyVersionsRequest{
+		AccessKeyUID: accessKeyUID,
+	})
+	if err != nil {
+		term.Spinner().Fail()
+		return fmt.Errorf("%w: %s", ErrListingKeyVersions, err)
+	}
+	tfCloudAccessData := populateCloudAccessData(section, key, versions.AccessKeyVersions)
+
+	term.Spinner().Start("Saving TF configurations ")
+	if err = templateProcessor.ProcessTemplates(tfCloudAccessData); err != nil {
+		term.Spinner().Fail()
+		return fmt.Errorf("%w: %s", ErrSavingFiles, err)
+	}
+
+	term.Spinner().OK()
+	term.Printf("Terraform configuration for cloudaccess key '%s' was saved successfully\n", tfCloudAccessData.Key.AccessKeyName)
+
+	return nil
+}
+
+func populateCloudAccessData(section string, key *cloudaccess.GetAccessKeyResponse, versions []cloudaccess.AccessKeyVersion) TFCloudAccessData {
+	var netConf *NetworkConfiguration
+	if key.NetworkConfiguration != nil {
+		netConf = &NetworkConfiguration{
+			AdditionalCDN:   string(key.NetworkConfiguration.AdditionalCDN),
+			SecurityNetwork: string(key.NetworkConfiguration.SecurityNetwork),
+		}
+	}
+
+	var contractID string
+	var groupID int64
+	if len(key.Groups) > 0 {
+		groupID = key.Groups[0].GroupID
+		if len(key.Groups[0].ContractIDs) > 0 {
+			contractID = key.Groups[0].ContractIDs[0]
+		}
+	}
+
+	tfCloudAccessData := TFCloudAccessData{
+		Section: section,
+		Key: TFCloudAccessKey{
+			KeyResourceName:      strings.ReplaceAll(key.AccessKeyName, "-", "_"),
+			AccessKeyName:        key.AccessKeyName,
+			AuthenticationMethod: key.AuthenticationMethod,
+			GroupID:              groupID,
+			ContractID:           contractID,
+			AccessKeyUID:         key.AccessKeyUID,
+			NetworkConfiguration: netConf,
+		},
+	}
+
+	versionNum := len(versions)
+	switch versionNum {
+	case 0:
+		return tfCloudAccessData
+	case 1:
+		tfCloudAccessData.Key.CredentialA = &Credential{
+			CloudAccessKeyID: *versions[0].CloudAccessKeyID,
+		}
+	default:
+		tfCloudAccessData.Key.CredentialA = &Credential{
+			CloudAccessKeyID: *versions[0].CloudAccessKeyID,
+		}
+		tfCloudAccessData.Key.CredentialB = &Credential{
+			CloudAccessKeyID: *versions[1].CloudAccessKeyID,
+		}
+	}
+
+	return tfCloudAccessData
+}

--- a/pkg/providers/cloudaccess/create_key.go
+++ b/pkg/providers/cloudaccess/create_key.go
@@ -46,7 +46,7 @@ type (
 
 	// NetworkConfiguration represents CLoudAccess network configuration
 	NetworkConfiguration struct {
-		AdditionalCDN   string
+		AdditionalCDN   *string
 		SecurityNetwork string
 	}
 )
@@ -148,8 +148,10 @@ func populateCloudAccessData(section string, key *cloudaccess.GetAccessKeyRespon
 	var netConf *NetworkConfiguration
 	if key.NetworkConfiguration != nil {
 		netConf = &NetworkConfiguration{
-			AdditionalCDN:   string(key.NetworkConfiguration.AdditionalCDN),
 			SecurityNetwork: string(key.NetworkConfiguration.SecurityNetwork),
+		}
+		if key.NetworkConfiguration.AdditionalCDN != nil {
+			netConf.AdditionalCDN = tools.StringPtr(string(*key.NetworkConfiguration.AdditionalCDN))
 		}
 	}
 

--- a/pkg/providers/cloudaccess/create_key.go
+++ b/pkg/providers/cloudaccess/create_key.go
@@ -2,11 +2,13 @@
 package cloudaccess
 
 import (
+	"cmp"
 	"context"
 	"embed"
 	"errors"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -186,11 +188,15 @@ func populateCloudAccessData(section string, key *cloudaccess.GetAccessKeyRespon
 			CloudAccessKeyID: *versions[0].CloudAccessKeyID,
 		}
 	default:
+		slices.SortFunc(versions, func(a, b cloudaccess.AccessKeyVersion) int {
+			return cmp.Compare(a.Version, b.Version)
+		})
+		// first version from the response from API is assigned to `credentials_b`, second version to `credentials_a`
 		tfCloudAccessData.Key.CredentialA = &Credential{
-			CloudAccessKeyID: *versions[0].CloudAccessKeyID,
+			CloudAccessKeyID: *versions[1].CloudAccessKeyID,
 		}
 		tfCloudAccessData.Key.CredentialB = &Credential{
-			CloudAccessKeyID: *versions[1].CloudAccessKeyID,
+			CloudAccessKeyID: *versions[0].CloudAccessKeyID,
 		}
 	}
 

--- a/pkg/providers/cloudaccess/create_key_test.go
+++ b/pkg/providers/cloudaccess/create_key_test.go
@@ -177,6 +177,40 @@ func TestCreateCloudAccess(t *testing.T) {
 				},
 			},
 		},
+		"error non unique cloud access key id": {
+			init: func(c *cloudaccess.Mock, p *templates.MockProcessor, dir string, data testDataForCloudAccess) {
+				mockGetAccessKey(c, data, nil)
+				mockListAccessKeyVersions(c, data, nil)
+			},
+			withError: ErrNonUniqueCloudAccessKeyID,
+			testData: testDataForCloudAccess{
+				section:              section,
+				accessKeyUID:         1,
+				accessKeyName:        "name1",
+				authenticationMethod: "AWS4_HMAC_SHA256",
+				networkConfiguration: &cloudaccess.SecureNetwork{
+					AdditionalCDN:   &chinaCDN,
+					SecurityNetwork: "ENHANCED_TLS",
+				},
+				groups: []cloudaccess.Group{
+					{
+						ContractIDs: []string{"ctr_111"},
+						GroupID:     11,
+						GroupName:   tools.StringPtr("group11"),
+					},
+				},
+				accessKeyVersions: []cloudaccess.AccessKeyVersion{
+					{
+						AccessKeyUID:     1,
+						CloudAccessKeyID: tools.StringPtr("key1"),
+					},
+					{
+						AccessKeyUID:     1,
+						CloudAccessKeyID: tools.StringPtr("key1"),
+					},
+				},
+			},
+		},
 		"error key has no group and contract safeguard": {
 			init: func(c *cloudaccess.Mock, p *templates.MockProcessor, dir string, data testDataForCloudAccess) {
 				mockGetAccessKey(c, data, nil)
@@ -350,8 +384,8 @@ func mockProcessTemplates(p *templates.MockProcessor, data testDataForCloudAcces
 		credA = &Credential{CloudAccessKeyID: *data.accessKeyVersions[0].CloudAccessKeyID}
 	}
 	if len(data.accessKeyVersions) == 2 {
-		credA = &Credential{CloudAccessKeyID: *data.accessKeyVersions[1].CloudAccessKeyID}
-		credB = &Credential{CloudAccessKeyID: *data.accessKeyVersions[0].CloudAccessKeyID}
+		credA = &Credential{CloudAccessKeyID: *data.accessKeyVersions[0].CloudAccessKeyID}
+		credB = &Credential{CloudAccessKeyID: *data.accessKeyVersions[1].CloudAccessKeyID}
 	}
 	var netConf *NetworkConfiguration
 	if data.networkConfiguration != nil {

--- a/pkg/providers/cloudaccess/create_key_test.go
+++ b/pkg/providers/cloudaccess/create_key_test.go
@@ -350,8 +350,8 @@ func mockProcessTemplates(p *templates.MockProcessor, data testDataForCloudAcces
 		credA = &Credential{CloudAccessKeyID: *data.accessKeyVersions[0].CloudAccessKeyID}
 	}
 	if len(data.accessKeyVersions) == 2 {
-		credA = &Credential{CloudAccessKeyID: *data.accessKeyVersions[0].CloudAccessKeyID}
-		credB = &Credential{CloudAccessKeyID: *data.accessKeyVersions[1].CloudAccessKeyID}
+		credA = &Credential{CloudAccessKeyID: *data.accessKeyVersions[1].CloudAccessKeyID}
+		credB = &Credential{CloudAccessKeyID: *data.accessKeyVersions[0].CloudAccessKeyID}
 	}
 	var netConf *NetworkConfiguration
 	if data.networkConfiguration != nil {

--- a/pkg/providers/cloudaccess/create_key_test.go
+++ b/pkg/providers/cloudaccess/create_key_test.go
@@ -1,0 +1,358 @@
+package cloudaccess
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v8/pkg/cloudaccess"
+	"github.com/akamai/cli-terraform/pkg/templates"
+	"github.com/akamai/cli-terraform/pkg/tools"
+	"github.com/akamai/cli/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(m *testing.M) {
+	if err := os.MkdirAll("./testdata/res", 0755); err != nil {
+		log.Fatal(err)
+	}
+	exitCode := m.Run()
+	if err := os.RemoveAll("./testdata/res"); err != nil {
+		log.Fatal(err)
+	}
+	os.Exit(exitCode)
+}
+
+var (
+	processor = func(testDir string) templates.FSTemplateProcessor {
+		return templates.FSTemplateProcessor{
+			TemplatesFS:     templateFiles,
+			AdditionalFuncs: additionalFunctions,
+			TemplateTargets: map[string]string{
+				"cloudaccess.tmpl": fmt.Sprintf("./testdata/res/%s/cloudaccess.tf", testDir),
+				"variables.tmpl":   fmt.Sprintf("./testdata/res/%s/variables.tf", testDir),
+				"imports.tmpl":     fmt.Sprintf("./testdata/res/%s/import.sh", testDir),
+			},
+		}
+	}
+	accessKeyUID = int64(1)
+	section      = "test_section"
+)
+
+func TestCreateCloudAccess(t *testing.T) {
+	tests := map[string]struct {
+		init      func(*cloudaccess.Mock, *templates.MockProcessor, string, testDataForCloudAccess)
+		dir       string
+		testData  testDataForCloudAccess
+		withError error
+	}{
+		"access key with two versions and all data": {
+			init: func(c *cloudaccess.Mock, p *templates.MockProcessor, dir string, data testDataForCloudAccess) {
+				mockGetAccessKey(c, data, nil)
+				mockListAccessKeyVersions(c, data, nil)
+				mockProcessTemplates(p, data)
+			},
+			dir: "two-versions",
+			testData: testDataForCloudAccess{
+				section:              section,
+				accessKeyUID:         1,
+				accessKeyName:        "name1",
+				authenticationMethod: "AWS4_HMAC_SHA256",
+				networkConfiguration: &cloudaccess.SecureNetwork{
+					AdditionalCDN:   "CHINA_CDN",
+					SecurityNetwork: "ENHANCED_TLS",
+				},
+				groups: []cloudaccess.Group{
+					{
+						ContractIDs: []string{"ctr_111"},
+						GroupID:     11,
+						GroupName:   tools.StringPtr("group11"),
+					},
+				},
+				accessKeyVersions: []cloudaccess.AccessKeyVersion{
+					{
+						AccessKeyUID:     1,
+						CloudAccessKeyID: tools.StringPtr("key1"),
+					},
+					{
+						AccessKeyUID:     1,
+						CloudAccessKeyID: tools.StringPtr("key2"),
+					},
+				},
+			},
+		},
+		"access key with one version": {
+			init: func(c *cloudaccess.Mock, p *templates.MockProcessor, dir string, data testDataForCloudAccess) {
+				mockGetAccessKey(c, data, nil)
+				mockListAccessKeyVersions(c, data, nil)
+				mockProcessTemplates(p, data)
+			},
+			dir: "one-version",
+			testData: testDataForCloudAccess{
+				section:              section,
+				accessKeyUID:         1,
+				accessKeyName:        "Test name1",
+				authenticationMethod: "AWS4_HMAC_SHA256",
+				networkConfiguration: &cloudaccess.SecureNetwork{
+					AdditionalCDN:   "CHINA_CDN",
+					SecurityNetwork: "ENHANCED_TLS",
+				},
+				groups: []cloudaccess.Group{
+					{
+						ContractIDs: []string{"ctr_111"},
+						GroupID:     11,
+						GroupName:   tools.StringPtr("group11"),
+					},
+				},
+				accessKeyVersions: []cloudaccess.AccessKeyVersion{
+					{
+						AccessKeyUID:     1,
+						CloudAccessKeyID: tools.StringPtr("key1"),
+					},
+				},
+			},
+		},
+		"access key with no versions": {
+			init: func(c *cloudaccess.Mock, p *templates.MockProcessor, dir string, data testDataForCloudAccess) {
+				mockGetAccessKey(c, data, nil)
+				mockListAccessKeyVersions(c, data, nil)
+				mockProcessTemplates(p, data)
+			},
+			dir: "no-versions",
+			testData: testDataForCloudAccess{
+				section:              section,
+				accessKeyUID:         1,
+				accessKeyName:        "name1",
+				authenticationMethod: "AWS4_HMAC_SHA256",
+				networkConfiguration: &cloudaccess.SecureNetwork{
+					AdditionalCDN:   "CHINA_CDN",
+					SecurityNetwork: "ENHANCED_TLS",
+				},
+				groups: []cloudaccess.Group{
+					{
+						ContractIDs: []string{"ctr_111"},
+						GroupID:     11,
+						GroupName:   tools.StringPtr("group11"),
+					},
+				},
+			},
+		},
+		"error getting access key": {
+			init: func(c *cloudaccess.Mock, p *templates.MockProcessor, dir string, data testDataForCloudAccess) {
+				mockGetAccessKey(c, data, ErrFetchingKey)
+			},
+			withError: ErrFetchingKey,
+			testData: testDataForCloudAccess{
+				accessKeyUID: 1,
+			},
+		},
+		"error listing access key versions": {
+			init: func(c *cloudaccess.Mock, p *templates.MockProcessor, dir string, data testDataForCloudAccess) {
+				mockGetAccessKey(c, data, nil)
+				mockListAccessKeyVersions(c, data, ErrListingKeyVersions)
+			},
+			withError: ErrListingKeyVersions,
+			testData: testDataForCloudAccess{
+				section:              section,
+				accessKeyUID:         1,
+				accessKeyName:        "name1",
+				authenticationMethod: "AWS4_HMAC_SHA256",
+				networkConfiguration: &cloudaccess.SecureNetwork{
+					AdditionalCDN:   "CHINA_CDN",
+					SecurityNetwork: "ENHANCED_TLS",
+				},
+				groups: []cloudaccess.Group{
+					{
+						ContractIDs: []string{"ctr_111"},
+						GroupID:     11,
+						GroupName:   tools.StringPtr("group11"),
+					},
+				},
+			},
+		},
+		"error key has no group and contract safeguard": {
+			init: func(c *cloudaccess.Mock, p *templates.MockProcessor, dir string, data testDataForCloudAccess) {
+				mockGetAccessKey(c, data, nil)
+			},
+			withError: ErrNoGroup,
+			testData: testDataForCloudAccess{
+				accessKeyUID: 1,
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.NoError(t, os.MkdirAll(fmt.Sprintf("./testdata/res/%s", test.dir), 0755))
+			mock := new(cloudaccess.Mock)
+			templateProcessor := new(templates.MockProcessor)
+			test.init(mock, templateProcessor, test.dir, test.testData)
+			ctx := terminal.Context(context.Background(), terminal.New(terminal.DiscardWriter(), nil, terminal.DiscardWriter()))
+			err := createCloudAccess(ctx, accessKeyUID, section, mock, templateProcessor)
+			if test.withError != nil {
+				assert.True(t, errors.Is(err, test.withError), "expected: %s; got: %s", test.withError, err)
+				return
+			}
+			require.NoError(t, err)
+			mock.AssertExpectations(t)
+			templateProcessor.AssertExpectations(t)
+		})
+	}
+}
+
+func TestProcessCloudAccessTemplates(t *testing.T) {
+	tests := map[string]struct {
+		givenData    TFCloudAccessData
+		dir          string
+		filesToCheck []string
+	}{
+		"access key with all data and two versions": {
+			givenData: TFCloudAccessData{
+				Key: TFCloudAccessKey{
+					KeyResourceName:      "TestKeyName",
+					AccessKeyName:        "TestKeyName",
+					AuthenticationMethod: "AWS4_HMAC_SHA256",
+					GroupID:              1234,
+					ContractID:           "C-Contract123",
+					AccessKeyUID:         1,
+					CredentialA:          &Credential{CloudAccessKeyID: "testAccessKey1"},
+					CredentialB:          &Credential{CloudAccessKeyID: "testAccessKey2"},
+					NetworkConfiguration: &NetworkConfiguration{
+						AdditionalCDN:   "CHINA_CDN",
+						SecurityNetwork: "ENHANCED_TLS",
+					},
+				},
+				Section: "test_section",
+			},
+			dir:          "two_versions",
+			filesToCheck: []string{"cloudaccess.tf", "import.sh", "variables.tf"},
+		},
+		"access key with all data and one version": {
+			givenData: TFCloudAccessData{
+				Key: TFCloudAccessKey{
+					KeyResourceName:      "TestKeyName",
+					AccessKeyName:        "TestKeyName",
+					AuthenticationMethod: "AWS4_HMAC_SHA256",
+					GroupID:              1234,
+					ContractID:           "C-Contract123",
+					AccessKeyUID:         1,
+					CredentialA:          &Credential{CloudAccessKeyID: "testAccessKey1"},
+					NetworkConfiguration: &NetworkConfiguration{
+						AdditionalCDN:   "CHINA_CDN",
+						SecurityNetwork: "ENHANCED_TLS",
+					},
+				},
+				Section: "test_section",
+			},
+			dir:          "one_version",
+			filesToCheck: []string{"cloudaccess.tf", "import.sh", "variables.tf"},
+		},
+		"access key with no versions": {
+			givenData: TFCloudAccessData{
+				Key: TFCloudAccessKey{
+					KeyResourceName:      "TestKeyName",
+					AccessKeyName:        "TestKeyName",
+					AuthenticationMethod: "AWS4_HMAC_SHA256",
+					GroupID:              1234,
+					ContractID:           "C-Contract123",
+					AccessKeyUID:         1,
+					NetworkConfiguration: &NetworkConfiguration{
+						AdditionalCDN:   "CHINA_CDN",
+						SecurityNetwork: "ENHANCED_TLS",
+					},
+				},
+				Section: "test_section",
+			},
+			dir:          "no_versions",
+			filesToCheck: []string{"cloudaccess.tf", "import.sh", "variables.tf"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.NoError(t, os.MkdirAll(fmt.Sprintf("./testdata/res/%s", test.dir), 0755))
+			require.NoError(t, processor(test.dir).ProcessTemplates(test.givenData))
+			for _, f := range test.filesToCheck {
+				expected, err := os.ReadFile(fmt.Sprintf("./testdata/%s/%s", test.dir, f))
+				require.NoError(t, err)
+				result, err := os.ReadFile(fmt.Sprintf("./testdata/res/%s/%s", test.dir, f))
+				require.NoError(t, err)
+				assert.Equal(t, string(expected), string(result))
+			}
+		})
+	}
+}
+
+type testDataForCloudAccess struct {
+	section              string
+	accessKeyUID         int64
+	accessKeyName        string
+	authenticationMethod string
+	networkConfiguration *cloudaccess.SecureNetwork
+	groups               []cloudaccess.Group
+	accessKeyVersions    []cloudaccess.AccessKeyVersion
+}
+
+func mockGetAccessKey(c *cloudaccess.Mock, data testDataForCloudAccess, err error) {
+	req := cloudaccess.AccessKeyRequest{
+		AccessKeyUID: data.accessKeyUID,
+	}
+	resp := &cloudaccess.GetAccessKeyResponse{
+		AccessKeyUID:         data.accessKeyUID,
+		AccessKeyName:        data.accessKeyName,
+		AuthenticationMethod: data.authenticationMethod,
+		NetworkConfiguration: data.networkConfiguration,
+		Groups:               data.groups,
+	}
+	c.On("GetAccessKey", mock.Anything, req).Return(resp, err).Once()
+}
+
+func mockListAccessKeyVersions(c *cloudaccess.Mock, data testDataForCloudAccess, err error) {
+	req := cloudaccess.ListAccessKeyVersionsRequest{
+		AccessKeyUID: data.accessKeyUID,
+	}
+	resp := &cloudaccess.ListAccessKeyVersionsResponse{
+		AccessKeyVersions: data.accessKeyVersions,
+	}
+	c.On("ListAccessKeyVersions", mock.Anything, req).Return(resp, err).Once()
+}
+
+func mockProcessTemplates(p *templates.MockProcessor, data testDataForCloudAccess) {
+	groupID := data.groups[0].GroupID
+	contractID := data.groups[0].ContractIDs[0]
+	var credA, credB *Credential
+	if len(data.accessKeyVersions) == 1 {
+		credA = &Credential{CloudAccessKeyID: *data.accessKeyVersions[0].CloudAccessKeyID}
+	}
+	if len(data.accessKeyVersions) == 2 {
+		credA = &Credential{CloudAccessKeyID: *data.accessKeyVersions[0].CloudAccessKeyID}
+		credB = &Credential{CloudAccessKeyID: *data.accessKeyVersions[1].CloudAccessKeyID}
+	}
+	var netConf *NetworkConfiguration
+	if data.networkConfiguration != nil {
+		netConf = &NetworkConfiguration{
+			AdditionalCDN:   string(data.networkConfiguration.AdditionalCDN),
+			SecurityNetwork: string(data.networkConfiguration.SecurityNetwork),
+		}
+	}
+	p.On("ProcessTemplates", TFCloudAccessData{
+		Key: TFCloudAccessKey{
+			KeyResourceName:      strings.ReplaceAll(data.accessKeyName, "-", "_"),
+			AccessKeyName:        data.accessKeyName,
+			AuthenticationMethod: data.authenticationMethod,
+			GroupID:              groupID,
+			ContractID:           contractID,
+			AccessKeyUID:         data.accessKeyUID,
+			CredentialA:          credA,
+			CredentialB:          credB,
+			NetworkConfiguration: netConf,
+		},
+		Section: data.section,
+	}).Return(nil).Once()
+}

--- a/pkg/providers/cloudaccess/create_key_test.go
+++ b/pkg/providers/cloudaccess/create_key_test.go
@@ -41,6 +41,7 @@ var (
 			},
 		}
 	}
+	chinaCDN     = cloudaccess.ChinaCDN
 	accessKeyUID = int64(1)
 	section      = "test_section"
 )
@@ -65,7 +66,7 @@ func TestCreateCloudAccess(t *testing.T) {
 				accessKeyName:        "name1",
 				authenticationMethod: "AWS4_HMAC_SHA256",
 				networkConfiguration: &cloudaccess.SecureNetwork{
-					AdditionalCDN:   "CHINA_CDN",
+					AdditionalCDN:   &chinaCDN,
 					SecurityNetwork: "ENHANCED_TLS",
 				},
 				groups: []cloudaccess.Group{
@@ -100,7 +101,7 @@ func TestCreateCloudAccess(t *testing.T) {
 				accessKeyName:        "Test name1",
 				authenticationMethod: "AWS4_HMAC_SHA256",
 				networkConfiguration: &cloudaccess.SecureNetwork{
-					AdditionalCDN:   "CHINA_CDN",
+					AdditionalCDN:   &chinaCDN,
 					SecurityNetwork: "ENHANCED_TLS",
 				},
 				groups: []cloudaccess.Group{
@@ -131,7 +132,7 @@ func TestCreateCloudAccess(t *testing.T) {
 				accessKeyName:        "name1",
 				authenticationMethod: "AWS4_HMAC_SHA256",
 				networkConfiguration: &cloudaccess.SecureNetwork{
-					AdditionalCDN:   "CHINA_CDN",
+					AdditionalCDN:   &chinaCDN,
 					SecurityNetwork: "ENHANCED_TLS",
 				},
 				groups: []cloudaccess.Group{
@@ -164,7 +165,7 @@ func TestCreateCloudAccess(t *testing.T) {
 				accessKeyName:        "name1",
 				authenticationMethod: "AWS4_HMAC_SHA256",
 				networkConfiguration: &cloudaccess.SecureNetwork{
-					AdditionalCDN:   "CHINA_CDN",
+					AdditionalCDN:   &chinaCDN,
 					SecurityNetwork: "ENHANCED_TLS",
 				},
 				groups: []cloudaccess.Group{
@@ -224,7 +225,7 @@ func TestProcessCloudAccessTemplates(t *testing.T) {
 					CredentialA:          &Credential{CloudAccessKeyID: "testAccessKey1"},
 					CredentialB:          &Credential{CloudAccessKeyID: "testAccessKey2"},
 					NetworkConfiguration: &NetworkConfiguration{
-						AdditionalCDN:   "CHINA_CDN",
+						AdditionalCDN:   tools.StringPtr("CHINA_CDN"),
 						SecurityNetwork: "ENHANCED_TLS",
 					},
 				},
@@ -244,7 +245,7 @@ func TestProcessCloudAccessTemplates(t *testing.T) {
 					AccessKeyUID:         1,
 					CredentialA:          &Credential{CloudAccessKeyID: "testAccessKey1"},
 					NetworkConfiguration: &NetworkConfiguration{
-						AdditionalCDN:   "CHINA_CDN",
+						AdditionalCDN:   tools.StringPtr("CHINA_CDN"),
 						SecurityNetwork: "ENHANCED_TLS",
 					},
 				},
@@ -263,13 +264,31 @@ func TestProcessCloudAccessTemplates(t *testing.T) {
 					ContractID:           "C-Contract123",
 					AccessKeyUID:         1,
 					NetworkConfiguration: &NetworkConfiguration{
-						AdditionalCDN:   "CHINA_CDN",
+						AdditionalCDN:   tools.StringPtr("CHINA_CDN"),
 						SecurityNetwork: "ENHANCED_TLS",
 					},
 				},
 				Section: "test_section",
 			},
 			dir:          "no_versions",
+			filesToCheck: []string{"cloudaccess.tf", "import.sh", "variables.tf"},
+		},
+		"access key with no versions and no additional cdn": {
+			givenData: TFCloudAccessData{
+				Key: TFCloudAccessKey{
+					KeyResourceName:      "TestKeyName",
+					AccessKeyName:        "TestKeyName",
+					AuthenticationMethod: "AWS4_HMAC_SHA256",
+					GroupID:              1234,
+					ContractID:           "C-Contract123",
+					AccessKeyUID:         1,
+					NetworkConfiguration: &NetworkConfiguration{
+						SecurityNetwork: "ENHANCED_TLS",
+					},
+				},
+				Section: "test_section",
+			},
+			dir:          "no_additional_cdn",
 			filesToCheck: []string{"cloudaccess.tf", "import.sh", "variables.tf"},
 		},
 	}
@@ -337,8 +356,10 @@ func mockProcessTemplates(p *templates.MockProcessor, data testDataForCloudAcces
 	var netConf *NetworkConfiguration
 	if data.networkConfiguration != nil {
 		netConf = &NetworkConfiguration{
-			AdditionalCDN:   string(data.networkConfiguration.AdditionalCDN),
 			SecurityNetwork: string(data.networkConfiguration.SecurityNetwork),
+		}
+		if data.networkConfiguration.AdditionalCDN != nil {
+			netConf.AdditionalCDN = tools.StringPtr(string(*data.networkConfiguration.AdditionalCDN))
 		}
 	}
 	p.On("ProcessTemplates", TFCloudAccessData{

--- a/pkg/providers/cloudaccess/templates/cloudaccess.tmpl
+++ b/pkg/providers/cloudaccess/templates/cloudaccess.tmpl
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/cloudaccess/templates/cloudaccess.tmpl
+++ b/pkg/providers/cloudaccess/templates/cloudaccess.tmpl
@@ -1,0 +1,42 @@
+{{- /*gotype: github.com/akamai/cli-terraform/pkg/providers/cloudaccess.TFCloudAccessData*/ -}}
+terraform {
+  required_providers {
+    akamai = {
+      source  = "akamai/akamai"
+      version = ">= 6.2.0"
+    }
+  }
+  required_version = ">= 1.0"
+}
+
+provider "akamai" {
+  edgerc         = var.edgerc_path
+  config_section = var.config_section
+}
+
+resource "akamai_cloudaccess_key" "{{.Key.KeyResourceName}}" {
+  access_key_name           = "{{.Key.AccessKeyName}}"
+  authentication_method     = "{{.Key.AuthenticationMethod}}"
+  group_id                  = {{.Key.GroupID}}
+  contract_id               = "{{.Key.ContractID}}"
+  {{- if .Key.NetworkConfiguration }}
+  network_configuration = {
+    additional_cdn          = "{{.Key.NetworkConfiguration.AdditionalCDN}}"
+    security_network        = "{{.Key.NetworkConfiguration.SecurityNetwork}}"
+  }
+  {{- end}}
+  {{- if .Key.CredentialA }}
+  credentials_a = {
+    cloud_access_key_id     = "{{.Key.CredentialA.CloudAccessKeyID}}"
+    cloud_secret_access_key = "PASTE YOUR SECRET HERE WHEN ROTATING A KEY"
+    primary_key             = false
+  }
+  {{- end}}
+  {{- if .Key.CredentialB }}
+  credentials_b = {
+    cloud_access_key_id     = "{{.Key.CredentialB.CloudAccessKeyID}}"
+    cloud_secret_access_key = "PASTE YOUR SECRET HERE WHEN ROTATING A KEY"
+    primary_key             = false
+  }
+  {{- end}}
+}

--- a/pkg/providers/cloudaccess/templates/cloudaccess.tmpl
+++ b/pkg/providers/cloudaccess/templates/cloudaccess.tmpl
@@ -21,7 +21,9 @@ resource "akamai_cloudaccess_key" "{{.Key.KeyResourceName}}" {
   contract_id               = "{{.Key.ContractID}}"
   {{- if .Key.NetworkConfiguration }}
   network_configuration = {
+    {{- if .Key.NetworkConfiguration.AdditionalCDN }}
     additional_cdn          = "{{.Key.NetworkConfiguration.AdditionalCDN}}"
+    {{- end}}
     security_network        = "{{.Key.NetworkConfiguration.SecurityNetwork}}"
   }
   {{- end}}

--- a/pkg/providers/cloudaccess/templates/imports.tmpl
+++ b/pkg/providers/cloudaccess/templates/imports.tmpl
@@ -1,0 +1,3 @@
+{{- /*gotype: github.com/akamai/cli-terraform/pkg/providers/cloudwrapper.TFCloudAccessData*/ -}}
+terraform init
+terraform import akamai_cloudaccess_key.{{.Key.KeyResourceName}} {{.Key.AccessKeyUID}}

--- a/pkg/providers/cloudaccess/templates/variables.tmpl
+++ b/pkg/providers/cloudaccess/templates/variables.tmpl
@@ -1,0 +1,10 @@
+{{- /*gotype: github.com/akamai/cli-terraform/pkg/providers/cloudaccess.TFCloudAccessData*/ -}}
+variable "edgerc_path" {
+  type = string
+  default = "~/.edgerc"
+}
+
+variable "config_section" {
+  type = string
+  default = "{{.Section}}"
+}

--- a/pkg/providers/cloudaccess/testdata/no_additional_cdn/cloudaccess.tf
+++ b/pkg/providers/cloudaccess/testdata/no_additional_cdn/cloudaccess.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    akamai = {
+      source  = "akamai/akamai"
+      version = ">= 6.2.0"
+    }
+  }
+  required_version = ">= 1.0"
+}
+
+provider "akamai" {
+  edgerc         = var.edgerc_path
+  config_section = var.config_section
+}
+
+resource "akamai_cloudaccess_key" "TestKeyName" {
+  access_key_name       = "TestKeyName"
+  authentication_method = "AWS4_HMAC_SHA256"
+  group_id              = 1234
+  contract_id           = "C-Contract123"
+  network_configuration = {
+    security_network = "ENHANCED_TLS"
+  }
+}

--- a/pkg/providers/cloudaccess/testdata/no_additional_cdn/cloudaccess.tf
+++ b/pkg/providers/cloudaccess/testdata/no_additional_cdn/cloudaccess.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/cloudaccess/testdata/no_additional_cdn/import.sh
+++ b/pkg/providers/cloudaccess/testdata/no_additional_cdn/import.sh
@@ -1,0 +1,2 @@
+terraform init
+terraform import akamai_cloudaccess_key.TestKeyName 1

--- a/pkg/providers/cloudaccess/testdata/no_additional_cdn/variables.tf
+++ b/pkg/providers/cloudaccess/testdata/no_additional_cdn/variables.tf
@@ -1,0 +1,9 @@
+variable "edgerc_path" {
+  type    = string
+  default = "~/.edgerc"
+}
+
+variable "config_section" {
+  type    = string
+  default = "test_section"
+}

--- a/pkg/providers/cloudaccess/testdata/no_versions/cloudaccess.tf
+++ b/pkg/providers/cloudaccess/testdata/no_versions/cloudaccess.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    akamai = {
+      source  = "akamai/akamai"
+      version = ">= 6.2.0"
+    }
+  }
+  required_version = ">= 1.0"
+}
+
+provider "akamai" {
+  edgerc         = var.edgerc_path
+  config_section = var.config_section
+}
+
+resource "akamai_cloudaccess_key" "TestKeyName" {
+  access_key_name       = "TestKeyName"
+  authentication_method = "AWS4_HMAC_SHA256"
+  group_id              = 1234
+  contract_id           = "C-Contract123"
+  network_configuration = {
+    additional_cdn   = "CHINA_CDN"
+    security_network = "ENHANCED_TLS"
+  }
+}

--- a/pkg/providers/cloudaccess/testdata/no_versions/cloudaccess.tf
+++ b/pkg/providers/cloudaccess/testdata/no_versions/cloudaccess.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/cloudaccess/testdata/no_versions/import.sh
+++ b/pkg/providers/cloudaccess/testdata/no_versions/import.sh
@@ -1,0 +1,2 @@
+terraform init
+terraform import akamai_cloudaccess_key.TestKeyName 1

--- a/pkg/providers/cloudaccess/testdata/no_versions/variables.tf
+++ b/pkg/providers/cloudaccess/testdata/no_versions/variables.tf
@@ -1,0 +1,9 @@
+variable "edgerc_path" {
+  type    = string
+  default = "~/.edgerc"
+}
+
+variable "config_section" {
+  type    = string
+  default = "test_section"
+}

--- a/pkg/providers/cloudaccess/testdata/one_version/cloudaccess.tf
+++ b/pkg/providers/cloudaccess/testdata/one_version/cloudaccess.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/cloudaccess/testdata/one_version/cloudaccess.tf
+++ b/pkg/providers/cloudaccess/testdata/one_version/cloudaccess.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_providers {
+    akamai = {
+      source  = "akamai/akamai"
+      version = ">= 6.2.0"
+    }
+  }
+  required_version = ">= 1.0"
+}
+
+provider "akamai" {
+  edgerc         = var.edgerc_path
+  config_section = var.config_section
+}
+
+resource "akamai_cloudaccess_key" "TestKeyName" {
+  access_key_name       = "TestKeyName"
+  authentication_method = "AWS4_HMAC_SHA256"
+  group_id              = 1234
+  contract_id           = "C-Contract123"
+  network_configuration = {
+    additional_cdn   = "CHINA_CDN"
+    security_network = "ENHANCED_TLS"
+  }
+  credentials_a = {
+    cloud_access_key_id     = "testAccessKey1"
+    cloud_secret_access_key = "PASTE YOUR SECRET HERE WHEN ROTATING A KEY"
+    primary_key             = false
+  }
+}

--- a/pkg/providers/cloudaccess/testdata/one_version/import.sh
+++ b/pkg/providers/cloudaccess/testdata/one_version/import.sh
@@ -1,0 +1,2 @@
+terraform init
+terraform import akamai_cloudaccess_key.TestKeyName 1

--- a/pkg/providers/cloudaccess/testdata/one_version/variables.tf
+++ b/pkg/providers/cloudaccess/testdata/one_version/variables.tf
@@ -1,0 +1,9 @@
+variable "edgerc_path" {
+  type    = string
+  default = "~/.edgerc"
+}
+
+variable "config_section" {
+  type    = string
+  default = "test_section"
+}

--- a/pkg/providers/cloudaccess/testdata/two_versions/cloudaccess.tf
+++ b/pkg/providers/cloudaccess/testdata/two_versions/cloudaccess.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_providers {
+    akamai = {
+      source  = "akamai/akamai"
+      version = ">= 6.2.0"
+    }
+  }
+  required_version = ">= 1.0"
+}
+
+provider "akamai" {
+  edgerc         = var.edgerc_path
+  config_section = var.config_section
+}
+
+resource "akamai_cloudaccess_key" "TestKeyName" {
+  access_key_name       = "TestKeyName"
+  authentication_method = "AWS4_HMAC_SHA256"
+  group_id              = 1234
+  contract_id           = "C-Contract123"
+  network_configuration = {
+    additional_cdn   = "CHINA_CDN"
+    security_network = "ENHANCED_TLS"
+  }
+  credentials_a = {
+    cloud_access_key_id     = "testAccessKey1"
+    cloud_secret_access_key = "PASTE YOUR SECRET HERE WHEN ROTATING A KEY"
+    primary_key             = false
+  }
+  credentials_b = {
+    cloud_access_key_id     = "testAccessKey2"
+    cloud_secret_access_key = "PASTE YOUR SECRET HERE WHEN ROTATING A KEY"
+    primary_key             = false
+  }
+}

--- a/pkg/providers/cloudaccess/testdata/two_versions/cloudaccess.tf
+++ b/pkg/providers/cloudaccess/testdata/two_versions/cloudaccess.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/cloudaccess/testdata/two_versions/import.sh
+++ b/pkg/providers/cloudaccess/testdata/two_versions/import.sh
@@ -1,0 +1,2 @@
+terraform init
+terraform import akamai_cloudaccess_key.TestKeyName 1

--- a/pkg/providers/cloudaccess/testdata/two_versions/variables.tf
+++ b/pkg/providers/cloudaccess/testdata/two_versions/variables.tf
@@ -1,0 +1,9 @@
+variable "edgerc_path" {
+  type    = string
+  default = "~/.edgerc"
+}
+
+variable "config_section" {
+  type    = string
+  default = "test_section"
+}

--- a/pkg/providers/papi/create_property.go
+++ b/pkg/providers/papi/create_property.go
@@ -52,6 +52,7 @@ type EdgeHostname struct {
 	SecurityType             string
 	UseCases                 string
 	CertificateID            int64
+	TTL                      int
 }
 
 // Hostname represents edge hostname resource
@@ -637,11 +638,16 @@ func getEdgeHostnameDetail(ctx context.Context, clientPAPI papi.PAPI, clientHAPI
 					}
 				}
 			}
+			ttl := 0
+			if !edgeHostname.UseDefaultTTL {
+				ttl = edgeHostname.TTL
+			}
 			edgeHostnamesMap[cnameToResource] = EdgeHostname{
 				EdgeHostname:             cnameTo,
 				EdgeHostnameID:           hostname.EdgeHostnameID,
 				ContractID:               property.ContractID,
 				GroupID:                  property.GroupID,
+				TTL:                      ttl,
 				IPv6:                     getIPv6(papiEdgeHostnames, hostname.EdgeHostnameID),
 				EdgeHostnameResourceName: cnameToResource,
 				SecurityType:             edgeHostname.SecurityType,

--- a/pkg/providers/papi/create_property.go
+++ b/pkg/providers/papi/create_property.go
@@ -207,7 +207,7 @@ var (
 
 var additionalFuncs = tools.DecorateWithMultilineHandlingFunctions(
 	map[string]any{
-		"TerraformName": TerraformName,
+		"TerraformName": tools.TerraformName,
 		"AsInt":         AsInt,
 		"ReportError":   ReportError,
 		"CheckErrors":   CheckErrors,
@@ -525,12 +525,12 @@ func flattenRules(property string, rule papi.Rules) []*WrappedRules {
 	result = append(result, flattenWrappedRules(wrappedRules)...)
 	var names = map[string]int{}
 	for _, wrappedRules := range result {
-		name := TerraformName(wrappedRules.Rule.Name)
+		name := tools.TerraformName(wrappedRules.Rule.Name)
 		names[name]++
 		if count := names[name]; count > 1 {
 			name = fmt.Sprintf("%s%d", name, count-1)
 		}
-		wrappedRules.TerraformName = fmt.Sprintf("%s_rule_%s", TerraformName(property), name)
+		wrappedRules.TerraformName = fmt.Sprintf("%s_rule_%s", tools.TerraformName(property), name)
 	}
 	return result
 }
@@ -983,28 +983,6 @@ func ruleNameNormalizer() func(string) string {
 
 func normalizeRuleName(name string) string {
 	return normalizeRuleNameRegexp.ReplaceAllString(name, "_")
-}
-
-var matchFirstCap = regexp.MustCompile("([^ _])([A-Z][a-z]+)")
-var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
-
-// ToSnakeCase returns name using snake case notation - SomeName -> some_name
-func ToSnakeCase(str string) string {
-	snake := strings.Replace(str, " ", "_", -1)
-	snake = matchFirstCap.ReplaceAllString(snake, "${1}_${2}")
-	snake = matchAllCap.ReplaceAllString(snake, "${1}_${2}")
-	return strings.ToLower(snake)
-}
-
-var nameRegexp = regexp.MustCompile(`[^\p{L}\p{Nl}\p{Mn}\p{Mc}\p{Nd}\p{Pc}\d\-_ ]`)
-
-// TerraformName is used to convert rule name into valid name of the exported data source
-// Current implementation is not covering all the cases defined in the terraform specification
-// https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md#identifiers and http://unicode.org/reports/tr31/ ,
-// but only a reasonable subset.
-func TerraformName(str string) string {
-	str = nameRegexp.ReplaceAllString(str, "-")
-	return ToSnakeCase(str)
 }
 
 // AsInt provides proper conversion of values which are integers in reality

--- a/pkg/providers/papi/create_property_test.go
+++ b/pkg/providers/papi/create_property_test.go
@@ -3014,7 +3014,7 @@ func TestTerraformName(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, test.expected, TerraformName(test.given))
+			assert.Equal(t, test.expected, tools.TerraformName(test.given))
 		})
 	}
 }

--- a/pkg/providers/papi/create_property_test.go
+++ b/pkg/providers/papi/create_property_test.go
@@ -2587,6 +2587,28 @@ func TestProcessPolicyTemplates(t *testing.T) {
 			filesToCheck: []string{"property.tf", "rules.tf", "variables.tf", "import.sh"},
 			filterFuncs:  []func([]string) ([]string, error){useThisOnlyRuleFormat("v2024-02-12")},
 		},
+		"property with rules as datasource - hcl rules version v2024-05-31": {
+			givenData: TFData{
+				Property: TFPropertyData{
+					GroupName:            "test_group",
+					GroupID:              "grp_12345",
+					ContractID:           "test_contract",
+					PropertyResourceName: "test-edgesuite-net",
+					PropertyName:         "test.edgesuite.net",
+					PropertyID:           "prp_12345",
+					ProductID:            "prd_HTTP_Content_Del",
+					ProductName:          "HTTP_Content_Del",
+					RuleFormat:           "v2024-05-31",
+					IsSecure:             "false",
+					ReadVersion:          "LATEST",
+				},
+				Section: "test_section",
+			},
+			dir:          "basic-rules-datasource-schema-v2024-05-31",
+			rulesAsHCL:   true,
+			filesToCheck: []string{"property.tf", "rules.tf", "variables.tf", "import.sh"},
+			filterFuncs:  []func([]string) ([]string, error){useThisOnlyRuleFormat("v2024-05-31")},
+		},
 		"property with bootstrap": {
 			givenData: TFData{
 				Property: TFPropertyData{

--- a/pkg/providers/papi/templates/property.tmpl
+++ b/pkg/providers/papi/templates/property.tmpl
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/templates/property.tmpl
+++ b/pkg/providers/papi/templates/property.tmpl
@@ -21,10 +21,13 @@ data "akamai_property_rules_template" "rules" {
 }{{end}}
 {{range .Property.EdgeHostnames}}
 resource "akamai_edge_hostname" "{{.EdgeHostnameResourceName}}" {
-  contract_id = var.contract_id
-  group_id = var.group_id
-  ip_behavior = "{{.IPv6}}"
+  contract_id   = var.contract_id
+  group_id      = var.group_id
+  ip_behavior   = "{{.IPv6}}"
   edge_hostname = "{{.EdgeHostname}}"
+{{- if .TTL}}
+  ttl           = {{.TTL}}
+{{- end}}
 {{- if .CertificateID}}
   certificate = {{.CertificateID}}
 {{- end}}

--- a/pkg/providers/papi/templates/rules_v2024-05-31.tmpl
+++ b/pkg/providers/papi/templates/rules_v2024-05-31.tmpl
@@ -1,0 +1,9817 @@
+{{- /*gotype: github.com/akamai/cli-terraform/pkg/providers/papi.TFData*/ -}}
+
+
+{{- define "Criteria"}}
+	{{- if eq .Name "advancedImMatch"}}{{- template "advancedImMatch" .}}
+	{{- else if eq .Name "bucket"}}{{- template "bucket" .}}
+	{{- else if eq .Name "cacheability"}}{{- template "cacheability" .}}
+	{{- else if eq .Name "chinaCdnRegion"}}{{- template "chinaCdnRegion" .}}
+	{{- else if eq .Name "clientCertificate"}}{{- template "clientCertificate" .}}
+	{{- else if eq .Name "clientIp"}}{{- template "clientIp" .}}
+	{{- else if eq .Name "clientIpVersion"}}{{- template "clientIpVersion" .}}
+	{{- else if eq .Name "cloudletsOrigin"}}{{- template "cloudletsOrigin" .}}
+	{{- else if eq .Name "contentDeliveryNetwork"}}{{- template "contentDeliveryNetwork" .}}
+	{{- else if eq .Name "contentType"}}{{- template "contentType" .}}
+	{{- else if eq .Name "deviceCharacteristic"}}{{- template "deviceCharacteristic" .}}
+	{{- else if eq .Name "ecmdAuthGroups"}}{{- template "ecmdAuthGroups" .}}
+	{{- else if eq .Name "ecmdAuthScheme"}}{{- template "ecmdAuthScheme" .}}
+	{{- else if eq .Name "ecmdIsAuthenticated"}}{{- template "ecmdIsAuthenticated" .}}
+	{{- else if eq .Name "ecmdUsername"}}{{- template "ecmdUsername" .}}
+	{{- else if eq .Name "edgeWorkersFailure"}}{{- template "edgeWorkersFailure" .}}
+	{{- else if eq .Name "fileExtension"}}{{- template "fileExtension" .}}
+	{{- else if eq .Name "filename"}}{{- template "filename" .}}
+	{{- else if eq .Name "hostname"}}{{- template "hostname" .}}
+	{{- else if eq .Name "matchAdvanced"}}{{- template "matchAdvanced" .}}
+	{{- else if eq .Name "matchCpCode"}}{{- template "matchCpCode" .}}
+	{{- else if eq .Name "matchResponseCode"}}{{- template "matchResponseCode" .}}
+	{{- else if eq .Name "matchVariable"}}{{- template "matchVariable" .}}
+	{{- else if eq .Name "metadataStage"}}{{- template "metadataStage" .}}
+	{{- else if eq .Name "originTimeout"}}{{- template "originTimeout" .}}
+	{{- else if eq .Name "path"}}{{- template "path" .}}
+	{{- else if eq .Name "queryStringParameter"}}{{- template "queryStringParameter" .}}
+	{{- else if eq .Name "random"}}{{- template "random" .}}
+	{{- else if eq .Name "recoveryConfig"}}{{- template "recoveryConfig" .}}
+	{{- else if eq .Name "regularExpression"}}{{- template "regularExpression" .}}
+	{{- else if eq .Name "requestCookie"}}{{- template "requestCookie" .}}
+	{{- else if eq .Name "requestHeader"}}{{- template "requestHeader" .}}
+	{{- else if eq .Name "requestMethod"}}{{- template "requestMethod" .}}
+	{{- else if eq .Name "requestProtocol"}}{{- template "requestProtocol" .}}
+	{{- else if eq .Name "requestType"}}{{- template "requestType" .}}
+	{{- else if eq .Name "responseHeader"}}{{- template "responseHeader" .}}
+	{{- else if eq .Name "serverLocation"}}{{- template "serverLocation" .}}
+	{{- else if eq .Name "time"}}{{- template "time" .}}
+	{{- else if eq .Name "tokenAuthorization"}}{{- template "tokenAuthorization" .}}
+	{{- else if eq .Name "userAgent"}}{{- template "userAgent" .}}
+	{{- else if eq .Name "userLocation"}}{{- template "userLocation" .}}
+	{{- else if eq .Name "userNetwork"}}{{- template "userNetwork" .}}
+	{{- else if eq .Name "variableError"}}{{- template "variableError" .}}
+	{{- else if eq .Name "virtualWaitingRoomRequest"}}{{- template "virtualWaitingRoomRequest" .}}
+	{{- else if eq .Name "visitorPrioritizationRequest"}}{{- template "visitorPrioritizationRequest" .}}
+	{{- else}}{{ReportError "Unknown criterion '%s'" .Name}}{{- end}}
+{{- end}}
+
+{{- define "Behavior"}}
+	{{- if eq .Name "adScalerCircuitBreaker"}}{{- template "adScalerCircuitBreaker" .}}
+	{{- else if eq .Name "adaptiveAcceleration"}}{{- template "adaptiveAcceleration" .}}
+	{{- else if eq .Name "adaptiveImageCompression"}}{{- template "adaptiveImageCompression" .}}
+	{{- else if eq .Name "advanced"}}{{- template "advanced" .}}
+	{{- else if eq .Name "aggregatedReporting"}}{{- template "aggregatedReporting" .}}
+	{{- else if eq .Name "akamaizer"}}{{- template "akamaizer" .}}
+	{{- else if eq .Name "akamaizerTag"}}{{- template "akamaizerTag" .}}
+	{{- else if eq .Name "allHttpInCacheHierarchy"}}{{- template "allHttpInCacheHierarchy" .}}
+	{{- else if eq .Name "allowCloudletsOrigins"}}{{- template "allowCloudletsOrigins" .}}
+	{{- else if eq .Name "allowDelete"}}{{- template "allowDelete" .}}
+	{{- else if eq .Name "allowHTTPSCacheKeySharing"}}{{- template "allowHTTPSCacheKeySharing" .}}
+	{{- else if eq .Name "allowHTTPSDowngrade"}}{{- template "allowHTTPSDowngrade" .}}
+	{{- else if eq .Name "allowOptions"}}{{- template "allowOptions" .}}
+	{{- else if eq .Name "allowPatch"}}{{- template "allowPatch" .}}
+	{{- else if eq .Name "allowPost"}}{{- template "allowPost" .}}
+	{{- else if eq .Name "allowPut"}}{{- template "allowPut" .}}
+	{{- else if eq .Name "allowTransferEncoding"}}{{- template "allowTransferEncoding" .}}
+	{{- else if eq .Name "altSvcHeader"}}{{- template "altSvcHeader" .}}
+	{{- else if eq .Name "apiPrioritization"}}{{- template "apiPrioritization" .}}
+	{{- else if eq .Name "applicationLoadBalancer"}}{{- template "applicationLoadBalancer" .}}
+	{{- else if eq .Name "audienceSegmentation"}}{{- template "audienceSegmentation" .}}
+	{{- else if eq .Name "autoDomainValidation"}}{{- template "autoDomainValidation" .}}
+	{{- else if eq .Name "baseDirectory"}}{{- template "baseDirectory" .}}
+	{{- else if eq .Name "bossBeaconing"}}{{- template "bossBeaconing" .}}
+	{{- else if eq .Name "breadcrumbs"}}{{- template "breadcrumbs" .}}
+	{{- else if eq .Name "breakConnection"}}{{- template "breakConnection" .}}
+	{{- else if eq .Name "brotli"}}{{- template "brotli" .}}
+	{{- else if eq .Name "cacheError"}}{{- template "cacheError" .}}
+	{{- else if eq .Name "cacheId"}}{{- template "cacheId" .}}
+	{{- else if eq .Name "cacheKeyIgnoreCase"}}{{- template "cacheKeyIgnoreCase" .}}
+	{{- else if eq .Name "cacheKeyQueryParams"}}{{- template "cacheKeyQueryParams" .}}
+	{{- else if eq .Name "cacheKeyRewrite"}}{{- template "cacheKeyRewrite" .}}
+	{{- else if eq .Name "cachePost"}}{{- template "cachePost" .}}
+	{{- else if eq .Name "cacheRedirect"}}{{- template "cacheRedirect" .}}
+	{{- else if eq .Name "cacheTag"}}{{- template "cacheTag" .}}
+	{{- else if eq .Name "cacheTagVisible"}}{{- template "cacheTagVisible" .}}
+	{{- else if eq .Name "caching"}}{{- template "caching" .}}
+	{{- else if eq .Name "centralAuthorization"}}{{- template "centralAuthorization" .}}
+	{{- else if eq .Name "chaseRedirects"}}{{- template "chaseRedirects" .}}
+	{{- else if eq .Name "clientCertificateAuth"}}{{- template "clientCertificateAuth" .}}
+	{{- else if eq .Name "clientCharacteristics"}}{{- template "clientCharacteristics" .}}
+	{{- else if eq .Name "cloudInterconnects"}}{{- template "cloudInterconnects" .}}
+	{{- else if eq .Name "cloudWrapper"}}{{- template "cloudWrapper" .}}
+	{{- else if eq .Name "cloudWrapperAdvanced"}}{{- template "cloudWrapperAdvanced" .}}
+	{{- else if eq .Name "commonMediaClientData"}}{{- template "commonMediaClientData" .}}
+	{{- else if eq .Name "conditionalOrigin"}}{{- template "conditionalOrigin" .}}
+	{{- else if eq .Name "constructResponse"}}{{- template "constructResponse" .}}
+	{{- else if eq .Name "contentCharacteristics"}}{{- template "contentCharacteristics" .}}
+	{{- else if eq .Name "contentCharacteristicsAMD"}}{{- template "contentCharacteristicsAMD" .}}
+	{{- else if eq .Name "contentCharacteristicsDD"}}{{- template "contentCharacteristicsDD" .}}
+	{{- else if eq .Name "contentCharacteristicsWsdLargeFile"}}{{- template "contentCharacteristicsWsdLargeFile" .}}
+	{{- else if eq .Name "contentCharacteristicsWsdLive"}}{{- template "contentCharacteristicsWsdLive" .}}
+	{{- else if eq .Name "contentCharacteristicsWsdVod"}}{{- template "contentCharacteristicsWsdVod" .}}
+	{{- else if eq .Name "contentPrePosition"}}{{- template "contentPrePosition" .}}
+	{{- else if eq .Name "contentTargetingProtection"}}{{- template "contentTargetingProtection" .}}
+	{{- else if eq .Name "corsSupport"}}{{- template "corsSupport" .}}
+	{{- else if eq .Name "cpCode"}}{{- template "cpCode" .}}
+	{{- else if eq .Name "customBehavior"}}{{- template "customBehavior" .}}
+	{{- else if eq .Name "datastream"}}{{- template "datastream" .}}
+	{{- else if eq .Name "dcp"}}{{- template "dcp" .}}
+	{{- else if eq .Name "dcpAuthHMACTransformation"}}{{- template "dcpAuthHMACTransformation" .}}
+	{{- else if eq .Name "dcpAuthRegexTransformation"}}{{- template "dcpAuthRegexTransformation" .}}
+	{{- else if eq .Name "dcpAuthSubstringTransformation"}}{{- template "dcpAuthSubstringTransformation" .}}
+	{{- else if eq .Name "dcpAuthVariableExtractor"}}{{- template "dcpAuthVariableExtractor" .}}
+	{{- else if eq .Name "dcpDefaultAuthzGroups"}}{{- template "dcpDefaultAuthzGroups" .}}
+	{{- else if eq .Name "dcpDevRelations"}}{{- template "dcpDevRelations" .}}
+	{{- else if eq .Name "dcpRealTimeAuth"}}{{- template "dcpRealTimeAuth" .}}
+	{{- else if eq .Name "deliveryReceipt"}}{{- template "deliveryReceipt" .}}
+	{{- else if eq .Name "denyAccess"}}{{- template "denyAccess" .}}
+	{{- else if eq .Name "denyDirectFailoverAccess"}}{{- template "denyDirectFailoverAccess" .}}
+	{{- else if eq .Name "deviceCharacteristicCacheId"}}{{- template "deviceCharacteristicCacheId" .}}
+	{{- else if eq .Name "deviceCharacteristicHeader"}}{{- template "deviceCharacteristicHeader" .}}
+	{{- else if eq .Name "dnsAsyncRefresh"}}{{- template "dnsAsyncRefresh" .}}
+	{{- else if eq .Name "dnsPrefresh"}}{{- template "dnsPrefresh" .}}
+	{{- else if eq .Name "downgradeProtocol"}}{{- template "downgradeProtocol" .}}
+	{{- else if eq .Name "downloadCompleteMarker"}}{{- template "downloadCompleteMarker" .}}
+	{{- else if eq .Name "downloadNotification"}}{{- template "downloadNotification" .}}
+	{{- else if eq .Name "downstreamCache"}}{{- template "downstreamCache" .}}
+	{{- else if eq .Name "dynamicThroughtputOptimization"}}{{- template "dynamicThroughtputOptimization" .}}
+	{{- else if eq .Name "dynamicThroughtputOptimizationOverride"}}{{- template "dynamicThroughtputOptimizationOverride" .}}
+	{{- else if eq .Name "dynamicWebContent"}}{{- template "dynamicWebContent" .}}
+	{{- else if eq .Name "earlyHints"}}{{- template "earlyHints" .}}
+	{{- else if eq .Name "ecmsBulkUpload"}}{{- template "ecmsBulkUpload" .}}
+	{{- else if eq .Name "ecmsDatabase"}}{{- template "ecmsDatabase" .}}
+	{{- else if eq .Name "ecmsDataset"}}{{- template "ecmsDataset" .}}
+	{{- else if eq .Name "ecmsObjectKey"}}{{- template "ecmsObjectKey" .}}
+	{{- else if eq .Name "edgeConnect"}}{{- template "edgeConnect" .}}
+	{{- else if eq .Name "edgeLoadBalancingAdvanced"}}{{- template "edgeLoadBalancingAdvanced" .}}
+	{{- else if eq .Name "edgeLoadBalancingDataCenter"}}{{- template "edgeLoadBalancingDataCenter" .}}
+	{{- else if eq .Name "edgeLoadBalancingOrigin"}}{{- template "edgeLoadBalancingOrigin" .}}
+	{{- else if eq .Name "edgeOriginAuthorization"}}{{- template "edgeOriginAuthorization" .}}
+	{{- else if eq .Name "edgeRedirector"}}{{- template "edgeRedirector" .}}
+	{{- else if eq .Name "edgeScape"}}{{- template "edgeScape" .}}
+	{{- else if eq .Name "edgeSideIncludes"}}{{- template "edgeSideIncludes" .}}
+	{{- else if eq .Name "edgeWorker"}}{{- template "edgeWorker" .}}
+	{{- else if eq .Name "enforceMtlsSettings"}}{{- template "enforceMtlsSettings" .}}
+	{{- else if eq .Name "enhancedAkamaiProtocol"}}{{- template "enhancedAkamaiProtocol" .}}
+	{{- else if eq .Name "enhancedProxyDetection"}}{{- template "enhancedProxyDetection" .}}
+	{{- else if eq .Name "epdForwardHeaderEnrichment"}}{{- template "epdForwardHeaderEnrichment" .}}
+	{{- else if eq .Name "failAction"}}{{- template "failAction" .}}
+	{{- else if eq .Name "failoverBotManagerFeatureCompatibility"}}{{- template "failoverBotManagerFeatureCompatibility" .}}
+	{{- else if eq .Name "fastInvalidate"}}{{- template "fastInvalidate" .}}
+	{{- else if eq .Name "fips"}}{{- template "fips" .}}
+	{{- else if eq .Name "firstPartyMarketing"}}{{- template "firstPartyMarketing" .}}
+	{{- else if eq .Name "firstPartyMarketingPlus"}}{{- template "firstPartyMarketingPlus" .}}
+	{{- else if eq .Name "forwardRewrite"}}{{- template "forwardRewrite" .}}
+	{{- else if eq .Name "g2oheader"}}{{- template "g2oheader" .}}
+	{{- else if eq .Name "globalRequestNumber"}}{{- template "globalRequestNumber" .}}
+	{{- else if eq .Name "graphqlCaching"}}{{- template "graphqlCaching" .}}
+	{{- else if eq .Name "gzipResponse"}}{{- template "gzipResponse" .}}
+	{{- else if eq .Name "hdDataAdvanced"}}{{- template "hdDataAdvanced" .}}
+	{{- else if eq .Name "healthDetection"}}{{- template "healthDetection" .}}
+	{{- else if eq .Name "hsafEipBinding"}}{{- template "hsafEipBinding" .}}
+	{{- else if eq .Name "http2"}}{{- template "http2" .}}
+	{{- else if eq .Name "http3"}}{{- template "http3" .}}
+	{{- else if eq .Name "httpStrictTransportSecurity"}}{{- template "httpStrictTransportSecurity" .}}
+	{{- else if eq .Name "httpToHttpsUpgrade"}}{{- template "httpToHttpsUpgrade" .}}
+	{{- else if eq .Name "imOverride"}}{{- template "imOverride" .}}
+	{{- else if eq .Name "imageAndVideoManager"}}{{- template "imageAndVideoManager" .}}
+	{{- else if eq .Name "imageManager"}}{{- template "imageManager" .}}
+	{{- else if eq .Name "imageManagerVideo"}}{{- template "imageManagerVideo" .}}
+	{{- else if eq .Name "include"}}{{- template "include" .}}
+	{{- else if eq .Name "instant"}}{{- template "instant" .}}
+	{{- else if eq .Name "instantConfig"}}{{- template "instantConfig" .}}
+	{{- else if eq .Name "largeFileOptimization"}}{{- template "largeFileOptimization" .}}
+	{{- else if eq .Name "largeFileOptimizationAdvanced"}}{{- template "largeFileOptimizationAdvanced" .}}
+	{{- else if eq .Name "limitBitRate"}}{{- template "limitBitRate" .}}
+	{{- else if eq .Name "logCustom"}}{{- template "logCustom" .}}
+	{{- else if eq .Name "mPulse"}}{{- template "mPulse" .}}
+	{{- else if eq .Name "manifestPersonalization"}}{{- template "manifestPersonalization" .}}
+	{{- else if eq .Name "manifestRerouting"}}{{- template "manifestRerouting" .}}
+	{{- else if eq .Name "manualServerPush"}}{{- template "manualServerPush" .}}
+	{{- else if eq .Name "mediaAcceleration"}}{{- template "mediaAcceleration" .}}
+	{{- else if eq .Name "mediaAccelerationQuicOptout"}}{{- template "mediaAccelerationQuicOptout" .}}
+	{{- else if eq .Name "mediaClient"}}{{- template "mediaClient" .}}
+	{{- else if eq .Name "mediaFileRetrievalOptimization"}}{{- template "mediaFileRetrievalOptimization" .}}
+	{{- else if eq .Name "mediaOriginFailover"}}{{- template "mediaOriginFailover" .}}
+	{{- else if eq .Name "metadataCaching"}}{{- template "metadataCaching" .}}
+	{{- else if eq .Name "mobileSdkPerformance"}}{{- template "mobileSdkPerformance" .}}
+	{{- else if eq .Name "modifyIncomingRequestHeader"}}{{- template "modifyIncomingRequestHeader" .}}
+	{{- else if eq .Name "modifyIncomingResponseHeader"}}{{- template "modifyIncomingResponseHeader" .}}
+	{{- else if eq .Name "modifyOutgoingRequestHeader"}}{{- template "modifyOutgoingRequestHeader" .}}
+	{{- else if eq .Name "modifyOutgoingResponseHeader"}}{{- template "modifyOutgoingResponseHeader" .}}
+	{{- else if eq .Name "modifyViaHeader"}}{{- template "modifyViaHeader" .}}
+	{{- else if eq .Name "origin"}}{{- template "origin" .}}
+	{{- else if eq .Name "originCharacteristics"}}{{- template "originCharacteristics" .}}
+	{{- else if eq .Name "originCharacteristicsWsd"}}{{- template "originCharacteristicsWsd" .}}
+	{{- else if eq .Name "originFailureRecoveryMethod"}}{{- template "originFailureRecoveryMethod" .}}
+	{{- else if eq .Name "originFailureRecoveryPolicy"}}{{- template "originFailureRecoveryPolicy" .}}
+	{{- else if eq .Name "originIpAcl"}}{{- template "originIpAcl" .}}
+	{{- else if eq .Name "permissionsPolicy"}}{{- template "permissionsPolicy" .}}
+	{{- else if eq .Name "persistentClientConnection"}}{{- template "persistentClientConnection" .}}
+	{{- else if eq .Name "persistentConnection"}}{{- template "persistentConnection" .}}
+	{{- else if eq .Name "personallyIdentifiableInformation"}}{{- template "personallyIdentifiableInformation" .}}
+	{{- else if eq .Name "phasedRelease"}}{{- template "phasedRelease" .}}
+	{{- else if eq .Name "preconnect"}}{{- template "preconnect" .}}
+	{{- else if eq .Name "predictiveContentDelivery"}}{{- template "predictiveContentDelivery" .}}
+	{{- else if eq .Name "predictivePrefetching"}}{{- template "predictivePrefetching" .}}
+	{{- else if eq .Name "prefetch"}}{{- template "prefetch" .}}
+	{{- else if eq .Name "prefetchable"}}{{- template "prefetchable" .}}
+	{{- else if eq .Name "prefreshCache"}}{{- template "prefreshCache" .}}
+	{{- else if eq .Name "quality"}}{{- template "quality" .}}
+	{{- else if eq .Name "quicBeta"}}{{- template "quicBeta" .}}
+	{{- else if eq .Name "randomSeek"}}{{- template "randomSeek" .}}
+	{{- else if eq .Name "rapid"}}{{- template "rapid" .}}
+	{{- else if eq .Name "readTimeout"}}{{- template "readTimeout" .}}
+	{{- else if eq .Name "realTimeReporting"}}{{- template "realTimeReporting" .}}
+	{{- else if eq .Name "realUserMonitoring"}}{{- template "realUserMonitoring" .}}
+	{{- else if eq .Name "redirect"}}{{- template "redirect" .}}
+	{{- else if eq .Name "redirectplus"}}{{- template "redirectplus" .}}
+	{{- else if eq .Name "refererChecking"}}{{- template "refererChecking" .}}
+	{{- else if eq .Name "removeQueryParameter"}}{{- template "removeQueryParameter" .}}
+	{{- else if eq .Name "removeVary"}}{{- template "removeVary" .}}
+	{{- else if eq .Name "report"}}{{- template "report" .}}
+	{{- else if eq .Name "requestClientHints"}}{{- template "requestClientHints" .}}
+	{{- else if eq .Name "requestControl"}}{{- template "requestControl" .}}
+	{{- else if eq .Name "requestTypeMarker"}}{{- template "requestTypeMarker" .}}
+	{{- else if eq .Name "resourceOptimizer"}}{{- template "resourceOptimizer" .}}
+	{{- else if eq .Name "resourceOptimizerExtendedCompatibility"}}{{- template "resourceOptimizerExtendedCompatibility" .}}
+	{{- else if eq .Name "responseCode"}}{{- template "responseCode" .}}
+	{{- else if eq .Name "responseCookie"}}{{- template "responseCookie" .}}
+	{{- else if eq .Name "restrictObjectCaching"}}{{- template "restrictObjectCaching" .}}
+	{{- else if eq .Name "returnCacheStatus"}}{{- template "returnCacheStatus" .}}
+	{{- else if eq .Name "rewriteUrl"}}{{- template "rewriteUrl" .}}
+	{{- else if eq .Name "rumCustom"}}{{- template "rumCustom" .}}
+	{{- else if eq .Name "saasDefinitions"}}{{- template "saasDefinitions" .}}
+	{{- else if eq .Name "salesForceCommerceCloudClient"}}{{- template "salesForceCommerceCloudClient" .}}
+	{{- else if eq .Name "salesForceCommerceCloudProvider"}}{{- template "salesForceCommerceCloudProvider" .}}
+	{{- else if eq .Name "salesForceCommerceCloudProviderHostHeader"}}{{- template "salesForceCommerceCloudProviderHostHeader" .}}
+	{{- else if eq .Name "savePostDcaProcessing"}}{{- template "savePostDcaProcessing" .}}
+	{{- else if eq .Name "scheduleInvalidation"}}{{- template "scheduleInvalidation" .}}
+	{{- else if eq .Name "scriptManagement"}}{{- template "scriptManagement" .}}
+	{{- else if eq .Name "segmentedContentProtection"}}{{- template "segmentedContentProtection" .}}
+	{{- else if eq .Name "segmentedMediaOptimization"}}{{- template "segmentedMediaOptimization" .}}
+	{{- else if eq .Name "segmentedMediaStreamingPrefetch"}}{{- template "segmentedMediaStreamingPrefetch" .}}
+	{{- else if eq .Name "setVariable"}}{{- template "setVariable" .}}
+	{{- else if eq .Name "simulateErrorCode"}}{{- template "simulateErrorCode" .}}
+	{{- else if eq .Name "siteShield"}}{{- template "siteShield" .}}
+	{{- else if eq .Name "standardTLSMigration"}}{{- template "standardTLSMigration" .}}
+	{{- else if eq .Name "standardTLSMigrationOverride"}}{{- template "standardTLSMigrationOverride" .}}
+	{{- else if eq .Name "strictHeaderParsing"}}{{- template "strictHeaderParsing" .}}
+	{{- else if eq .Name "subCustomer"}}{{- template "subCustomer" .}}
+	{{- else if eq .Name "sureRoute"}}{{- template "sureRoute" .}}
+	{{- else if eq .Name "tcpOptimization"}}{{- template "tcpOptimization" .}}
+	{{- else if eq .Name "teaLeaf"}}{{- template "teaLeaf" .}}
+	{{- else if eq .Name "tieredDistribution"}}{{- template "tieredDistribution" .}}
+	{{- else if eq .Name "tieredDistributionAdvanced"}}{{- template "tieredDistributionAdvanced" .}}
+	{{- else if eq .Name "tieredDistributionCustomization"}}{{- template "tieredDistributionCustomization" .}}
+	{{- else if eq .Name "timeout"}}{{- template "timeout" .}}
+	{{- else if eq .Name "uidConfiguration"}}{{- template "uidConfiguration" .}}
+	{{- else if eq .Name "validateEntityTag"}}{{- template "validateEntityTag" .}}
+	{{- else if eq .Name "verifyJsonWebToken"}}{{- template "verifyJsonWebToken" .}}
+	{{- else if eq .Name "verifyJsonWebTokenForDcp"}}{{- template "verifyJsonWebTokenForDcp" .}}
+	{{- else if eq .Name "verifyTokenAuthorization"}}{{- template "verifyTokenAuthorization" .}}
+	{{- else if eq .Name "virtualWaitingRoom"}}{{- template "virtualWaitingRoom" .}}
+	{{- else if eq .Name "virtualWaitingRoomWithEdgeWorkers"}}{{- template "virtualWaitingRoomWithEdgeWorkers" .}}
+	{{- else if eq .Name "visitorPrioritization"}}{{- template "visitorPrioritization" .}}
+	{{- else if eq .Name "visitorPrioritizationFifo"}}{{- template "visitorPrioritizationFifo" .}}
+	{{- else if eq .Name "visitorPrioritizationFifoStandalone"}}{{- template "visitorPrioritizationFifoStandalone" .}}
+	{{- else if eq .Name "watermarking"}}{{- template "watermarking" .}}
+	{{- else if eq .Name "webApplicationFirewall"}}{{- template "webApplicationFirewall" .}}
+	{{- else if eq .Name "webSockets"}}{{- template "webSockets" .}}
+	{{- else if eq .Name "webdav"}}{{- template "webdav" .}}
+    {{- else}}{{ReportError "Unknown behavior '%s'" .Name}}{{- end}}
+{{- end}}
+
+
+{{- define "adScalerCircuitBreaker"}}
+ad_scaler_circuit_breaker {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "responseDelayBased") (ne $v nil)}}
+		response_delay_based = {{$v}}
+{{- end}}
+{{- if and (eq $k "responseDelayThreshold") (ne $v nil)}}
+        response_delay_threshold = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "responseCodeBased") (ne $v nil)}}
+		response_code_based = {{$v}}
+{{- end}}
+{{- if and (eq $k "responseCodes") (ne $v nil)}}
+        response_codes = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "fallbackActionResponseCodeBased") (ne $v nil)}}
+        fallback_action_response_code_based = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "returnErrorResponseCodeBased") (ne $v nil)}}
+        return_error_response_code_based = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "specifyYourOwnResponseCodeBased") (ne $v nil)}}
+        specify_your_own_response_code_based = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "adaptiveAcceleration"}}
+adaptive_acceleration {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "source") (ne $v nil)}}
+        source = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "titleHttp2ServerPush") (ne $v nil)}}
+        title_http2_server_push = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "enablePush") (ne $v nil)}}
+		enable_push = {{$v}}
+{{- end}}
+{{- if and (eq $k "titlePreconnect") (ne $v nil)}}
+        title_preconnect = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "enablePreconnect") (ne $v nil)}}
+		enable_preconnect = {{$v}}
+{{- end}}
+{{- if and (eq $k "titlePreload") (ne $v nil)}}
+        title_preload = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "preloadEnable") (ne $v nil)}}
+		preload_enable = {{$v}}
+{{- end}}
+{{- if and (eq $k "abTesting") (ne $v nil)}}
+        ab_testing = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "abLogic") (ne $v nil)}}
+        ab_logic = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "cookieName") (ne $v nil)}}
+        cookie_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "compression") (ne $v nil)}}
+        compression = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "titleRo") (ne $v nil)}}
+        title_ro = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "enableRo") (ne $v nil)}}
+		enable_ro = {{$v}}
+{{- end}}
+{{- if and (eq $k "titleBrotli") (ne $v nil)}}
+        title_brotli = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "enableBrotliCompression") (ne $v nil)}}
+		enable_brotli_compression = {{$v}}
+{{- end}}
+{{- if and (eq $k "enableForNoncacheable") (ne $v nil)}}
+		enable_for_noncacheable = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "adaptiveImageCompression"}}
+adaptive_image_compression {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "title_aic_mobile") (ne $v nil)}}
+        title_aic_mobile = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "compressMobile") (ne $v nil)}}
+		compress_mobile = {{$v}}
+{{- end}}
+{{- if and (eq $k "tier1MobileCompressionMethod") (ne $v nil)}}
+        tier1_mobile_compression_method = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "tier1MobileCompressionValue") (ne $v nil)}}
+		tier1_mobile_compression_value = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "tier2MobileCompressionMethod") (ne $v nil)}}
+        tier2_mobile_compression_method = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "tier2MobileCompressionValue") (ne $v nil)}}
+		tier2_mobile_compression_value = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "tier3MobileCompressionMethod") (ne $v nil)}}
+        tier3_mobile_compression_method = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "tier3MobileCompressionValue") (ne $v nil)}}
+		tier3_mobile_compression_value = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "title_aic_nonmobile") (ne $v nil)}}
+        title_aic_nonmobile = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "compressStandard") (ne $v nil)}}
+		compress_standard = {{$v}}
+{{- end}}
+{{- if and (eq $k "tier1StandardCompressionMethod") (ne $v nil)}}
+        tier1_standard_compression_method = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "tier1StandardCompressionValue") (ne $v nil)}}
+		tier1_standard_compression_value = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "tier2StandardCompressionMethod") (ne $v nil)}}
+        tier2_standard_compression_method = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "tier2StandardCompressionValue") (ne $v nil)}}
+		tier2_standard_compression_value = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "tier3StandardCompressionMethod") (ne $v nil)}}
+        tier3_standard_compression_method = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "tier3StandardCompressionValue") (ne $v nil)}}
+		tier3_standard_compression_value = {{$v | AsInt}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "advanced"}}
+advanced {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "description") (ne $v nil)}}
+        description = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "xml") (ne $v nil)}}
+        xml = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "aggregatedReporting"}}
+aggregated_reporting {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "reportName") (ne $v nil)}}
+        report_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "attributesCount") (ne $v nil)}}
+		attributes_count = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "attribute1") (ne $v nil)}}
+        attribute1 = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "attribute2") (ne $v nil)}}
+        attribute2 = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "attribute3") (ne $v nil)}}
+        attribute3 = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "attribute4") (ne $v nil)}}
+        attribute4 = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "akamaizer"}}
+akamaizer {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "akamaizerTag"}}
+akamaizer_tag {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchHostname") (ne $v nil)}}
+        match_hostname = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "replacementHostname") (ne $v nil)}}
+        replacement_hostname = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "scope") (ne $v nil)}}
+        scope = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "tagsAttribute") (ne $v nil)}}
+        tags_attribute = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "replaceAll") (ne $v nil)}}
+		replace_all = {{$v}}
+{{- end}}
+{{- if and (eq $k "includeTagsAttribute") (ne $v nil)}}
+		include_tags_attribute = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "allHttpInCacheHierarchy"}}
+all_http_in_cache_hierarchy {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "allowCloudletsOrigins"}}
+allow_cloudlets_origins {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "honorBaseDirectory") (ne $v nil)}}
+		honor_base_directory = {{$v}}
+{{- end}}
+{{- if and (eq $k "purgeOriginQueryParameter") (ne $v nil)}}
+        purge_origin_query_parameter = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "allowDelete"}}
+allow_delete {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "allowBody") (ne $v nil)}}
+		allow_body = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "allowHTTPSCacheKeySharing"}}
+allow_https_cache_key_sharing {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "allowHTTPSDowngrade"}}
+allow_https_downgrade {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "allowOptions"}}
+allow_options {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "allowPatch"}}
+allow_patch {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "allowPost"}}
+allow_post {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "allowWithoutContentLength") (ne $v nil)}}
+		allow_without_content_length = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "allowPut"}}
+allow_put {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "allowTransferEncoding"}}
+allow_transfer_encoding {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "altSvcHeader"}}
+alt_svc_header {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "maxAge") (ne $v nil)}}
+		max_age = {{$v | AsInt}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "apiPrioritization"}}
+api_prioritization {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "isSharedPolicy") (ne $v nil)}}
+		is_shared_policy = {{$v}}
+{{- end}}
+{{- if eq $k "cloudletPolicy" }}
+		{{- if $v}}
+		cloudlet_policy {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "id") (ne $v nil)}}
+		id = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "name") (ne $v nil)}}
+        name = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "cloudletSharedPolicy") (ne $v nil)}}
+		cloudlet_shared_policy = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "label") (ne $v nil)}}
+        label = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "useThrottledCpCode") (ne $v nil)}}
+		use_throttled_cp_code = {{$v}}
+{{- end}}
+{{- if eq $k "throttledCpCode" }}
+		{{- if $v}}
+		throttled_cp_code {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "id") (ne $v nil)}}
+		id = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "name") (ne $v nil)}}
+        name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "createdDate") (ne $v nil)}}
+		created_date = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "description") (ne $v nil)}}
+        description = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "products"}}
+		products = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "cpCodeLimits" }}
+		{{- if $v}}
+		cp_code_limits {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "currentCapacity") (ne $v nil)}}
+		current_capacity = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "limit") (ne $v nil)}}
+		limit = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "limitType") (ne $v nil)}}
+        limit_type = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "useThrottledStatusCode") (ne $v nil)}}
+		use_throttled_status_code = {{$v}}
+{{- end}}
+{{- if and (eq $k "throttledStatusCode") (ne $v nil)}}
+		throttled_status_code = {{$v | AsInt}}
+{{- end}}
+{{- if eq $k "netStorage" }}
+		{{- if $v}}
+		net_storage {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "cpCode") (ne $v nil)}}
+		cp_code = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "downloadDomainName") (ne $v nil)}}
+        download_domain_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "g2oToken") (ne $v nil)}}
+        g2o_token = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "netStoragePath") (ne $v nil)}}
+        net_storage_path = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "alternateResponseCacheTtl") (ne $v nil)}}
+		alternate_response_cache_ttl = {{$v | AsInt}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "applicationLoadBalancer"}}
+application_load_balancer {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if eq $k "cloudletPolicy" }}
+		{{- if $v}}
+		cloudlet_policy {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "id") (ne $v nil)}}
+		id = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "name") (ne $v nil)}}
+        name = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "label") (ne $v nil)}}
+        label = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "stickinessTitle") (ne $v nil)}}
+        stickiness_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "stickinessCookieType") (ne $v nil)}}
+        stickiness_cookie_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "stickinessExpirationDate") (ne $v nil)}}
+        stickiness_expiration_date = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "stickinessDuration") (ne $v nil)}}
+        stickiness_duration = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "stickinessRefresh") (ne $v nil)}}
+		stickiness_refresh = {{$v}}
+{{- end}}
+{{- if and (eq $k "originCookieName") (ne $v nil)}}
+        origin_cookie_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "specifyStickinessCookieDomain") (ne $v nil)}}
+		specify_stickiness_cookie_domain = {{$v}}
+{{- end}}
+{{- if and (eq $k "stickinessCookieDomain") (ne $v nil)}}
+        stickiness_cookie_domain = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "stickinessCookieAutomaticSalt") (ne $v nil)}}
+		stickiness_cookie_automatic_salt = {{$v}}
+{{- end}}
+{{- if and (eq $k "stickinessCookieSalt") (ne $v nil)}}
+        stickiness_cookie_salt = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "stickinessCookieSetHttpOnlyFlag") (ne $v nil)}}
+		stickiness_cookie_set_http_only_flag = {{$v}}
+{{- end}}
+{{- if and (eq $k "allDownTitle") (ne $v nil)}}
+        all_down_title = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "allDownNetStorage" }}
+		{{- if $v}}
+		all_down_net_storage {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "cpCode") (ne $v nil)}}
+		cp_code = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "downloadDomainName") (ne $v nil)}}
+        download_domain_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "g2oToken") (ne $v nil)}}
+        g2o_token = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "allDownNetStorageFile") (ne $v nil)}}
+        all_down_net_storage_file = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "allDownStatusCode") (ne $v nil)}}
+        all_down_status_code = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "failoverTitle") (ne $v nil)}}
+        failover_title = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "failoverStatusCodes"}}
+		failover_status_codes = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "failoverMode") (ne $v nil)}}
+        failover_mode = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "failoverOriginMap" }}
+		{{- range $v := $v}}
+		failover_origin_map {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "fromOriginId") (ne $v nil)}}
+        from_origin_id = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "toOriginIds"}}
+		to_origin_ids = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- end}}
+		}
+{{- end}}
+{{- end}}
+{{- if and (eq $k "failoverAttemptsThreshold") (ne $v nil)}}
+		failover_attempts_threshold = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "cachedContentTitle") (ne $v nil)}}
+        cached_content_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "allowCachePrefresh") (ne $v nil)}}
+		allow_cache_prefresh = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "audienceSegmentation"}}
+audience_segmentation {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "isSharedPolicy") (ne $v nil)}}
+		is_shared_policy = {{$v}}
+{{- end}}
+{{- if eq $k "cloudletPolicy" }}
+		{{- if $v}}
+		cloudlet_policy {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "id") (ne $v nil)}}
+		id = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "name") (ne $v nil)}}
+        name = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "cloudletSharedPolicy") (ne $v nil)}}
+		cloudlet_shared_policy = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "label") (ne $v nil)}}
+        label = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "segmentTrackingTitle") (ne $v nil)}}
+        segment_tracking_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "segmentTrackingMethod") (ne $v nil)}}
+        segment_tracking_method = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "segmentTrackingQueryParam") (ne $v nil)}}
+        segment_tracking_query_param = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "segmentTrackingCookieName") (ne $v nil)}}
+        segment_tracking_cookie_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "segmentTrackingCustomHeader") (ne $v nil)}}
+        segment_tracking_custom_header = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "populationTitle") (ne $v nil)}}
+        population_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "populationCookieType") (ne $v nil)}}
+        population_cookie_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "populationDuration") (ne $v nil)}}
+        population_duration = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "populationRefresh") (ne $v nil)}}
+		population_refresh = {{$v}}
+{{- end}}
+{{- if and (eq $k "specifyPopulationCookieDomain") (ne $v nil)}}
+		specify_population_cookie_domain = {{$v}}
+{{- end}}
+{{- if and (eq $k "populationCookieDomain") (ne $v nil)}}
+        population_cookie_domain = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "populationCookieAutomaticSalt") (ne $v nil)}}
+		population_cookie_automatic_salt = {{$v}}
+{{- end}}
+{{- if and (eq $k "populationCookieSalt") (ne $v nil)}}
+        population_cookie_salt = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "populationCookieIncludeRuleName") (ne $v nil)}}
+		population_cookie_include_rule_name = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "autoDomainValidation"}}
+auto_domain_validation {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "autodv") (ne $v nil)}}
+        autodv = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "baseDirectory"}}
+base_directory {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "value") (ne $v nil)}}
+        value = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "bossBeaconing"}}
+boss_beaconing {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "cpcodes") (ne $v nil)}}
+        cpcodes = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "requestType") (ne $v nil)}}
+        request_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "forwardType") (ne $v nil)}}
+        forward_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "samplingFrequency") (ne $v nil)}}
+        sampling_frequency = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "conditionalSamplingFrequency") (ne $v nil)}}
+        conditional_sampling_frequency = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "conditionalHTTPStatus"}}
+		conditional_http_status = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "conditionalErrorPattern") (ne $v nil)}}
+        conditional_error_pattern = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "breadcrumbs"}}
+breadcrumbs {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "optMode") (ne $v nil)}}
+		opt_mode = {{$v}}
+{{- end}}
+{{- if and (eq $k "loggingEnabled") (ne $v nil)}}
+		logging_enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "breakConnection"}}
+break_connection {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "brotli"}}
+brotli {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "cacheError"}}
+cache_error {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "ttl") (ne $v nil)}}
+        ttl = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "preserveStale") (ne $v nil)}}
+		preserve_stale = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "cacheId"}}
+cache_id {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "rule") (ne $v nil)}}
+        rule = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "includeValue") (ne $v nil)}}
+		include_value = {{$v}}
+{{- end}}
+{{- if and (eq $k "optional") (ne $v nil)}}
+		optional = {{$v}}
+{{- end}}
+{{- if eq $k "elements"}}
+		elements = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "variableName") (ne $v nil)}}
+        variable_name = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "cacheKeyIgnoreCase"}}
+cache_key_ignore_case {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "cacheKeyQueryParams"}}
+cache_key_query_params {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "behavior") (ne $v nil)}}
+        behavior = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "parameters"}}
+		parameters = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "exactMatch") (ne $v nil)}}
+		exact_match = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "cacheKeyRewrite"}}
+cache_key_rewrite {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "purgeKey") (ne $v nil)}}
+        purge_key = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "cachePost"}}
+cache_post {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "useBody") (ne $v nil)}}
+        use_body = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "cacheRedirect"}}
+cache_redirect {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+        enabled = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "cacheTag"}}
+cache_tag {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "tag") (ne $v nil)}}
+        tag = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "cacheTagVisible"}}
+cache_tag_visible {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "behavior") (ne $v nil)}}
+        behavior = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "caching"}}
+caching {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "behavior") (ne $v nil)}}
+        behavior = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "mustRevalidate") (ne $v nil)}}
+		must_revalidate = {{$v}}
+{{- end}}
+{{- if and (eq $k "ttl") (ne $v nil)}}
+        ttl = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "defaultTtl") (ne $v nil)}}
+        default_ttl = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "cacheControlDirectives") (ne $v nil)}}
+        cache_control_directives = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "enhancedRfcSupport") (ne $v nil)}}
+		enhanced_rfc_support = {{$v}}
+{{- end}}
+{{- if and (eq $k "cacheabilitySettings") (ne $v nil)}}
+        cacheability_settings = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "honorNoStore") (ne $v nil)}}
+		honor_no_store = {{$v}}
+{{- end}}
+{{- if and (eq $k "honorPrivate") (ne $v nil)}}
+		honor_private = {{$v}}
+{{- end}}
+{{- if and (eq $k "honorNoCache") (ne $v nil)}}
+		honor_no_cache = {{$v}}
+{{- end}}
+{{- if and (eq $k "expirationSettings") (ne $v nil)}}
+        expiration_settings = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "honorMaxAge") (ne $v nil)}}
+		honor_max_age = {{$v}}
+{{- end}}
+{{- if and (eq $k "honorSMaxage") (ne $v nil)}}
+		honor_s_maxage = {{$v}}
+{{- end}}
+{{- if and (eq $k "revalidationSettings") (ne $v nil)}}
+        revalidation_settings = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "honorMustRevalidate") (ne $v nil)}}
+		honor_must_revalidate = {{$v}}
+{{- end}}
+{{- if and (eq $k "honorProxyRevalidate") (ne $v nil)}}
+		honor_proxy_revalidate = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "centralAuthorization"}}
+central_authorization {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "chaseRedirects"}}
+chase_redirects {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "limit") (ne $v nil)}}
+        limit = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "serve404") (ne $v nil)}}
+		serve404 = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "clientCertificateAuth"}}
+client_certificate_auth {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enable") (ne $v nil)}}
+		enable = {{$v}}
+{{- end}}
+{{- if and (eq $k "enableCompleteClientCertificate") (ne $v nil)}}
+		enable_complete_client_certificate = {{$v}}
+{{- end}}
+{{- if eq $k "clientCertificateAttributes"}}
+		client_certificate_attributes = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "enableClientCertificateValidationStatus") (ne $v nil)}}
+		enable_client_certificate_validation_status = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "clientCharacteristics"}}
+client_characteristics {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "country") (ne $v nil)}}
+        country = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "cloudInterconnects"}}
+cloud_interconnects {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if eq $k "cloudLocations"}}
+		cloud_locations = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "cloudWrapper"}}
+cloud_wrapper {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "location") (ne $v nil)}}
+        location = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "cloudWrapperAdvanced"}}
+cloud_wrapper_advanced {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "failoverMap") (ne $v nil)}}
+        failover_map = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "customFailoverMap") (ne $v nil)}}
+        custom_failover_map = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "commonMediaClientData"}}
+common_media_client_data {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enableCMCDSegmentPrefetch") (ne $v nil)}}
+		enable_cmcd_segment_prefetch = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "conditionalOrigin"}}
+conditional_origin {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "originId") (ne $v nil)}}
+        origin_id = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "constructResponse"}}
+construct_response {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "body") (ne $v nil)}}
+        body = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "responseCode") (ne $v nil)}}
+		response_code = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "forceEviction") (ne $v nil)}}
+		force_eviction = {{$v}}
+{{- end}}
+{{- if and (eq $k "ignorePurge") (ne $v nil)}}
+		ignore_purge = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "contentCharacteristics"}}
+content_characteristics {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "objectSize") (ne $v nil)}}
+        object_size = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "popularityDistribution") (ne $v nil)}}
+        popularity_distribution = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "catalogSize") (ne $v nil)}}
+        catalog_size = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "contentType") (ne $v nil)}}
+        content_type = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "contentCharacteristicsAMD"}}
+content_characteristics_amd {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "catalogSize") (ne $v nil)}}
+        catalog_size = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "contentType") (ne $v nil)}}
+        content_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "popularityDistribution") (ne $v nil)}}
+        popularity_distribution = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "hls") (ne $v nil)}}
+		hls = {{$v}}
+{{- end}}
+{{- if and (eq $k "segmentDurationHLS") (ne $v nil)}}
+        segment_duration_hls = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "segmentDurationHLSCustom") (ne $v nil)}}
+		segment_duration_hls_custom = {{$v}}
+{{- end}}
+{{- if and (eq $k "segmentSizeHLS") (ne $v nil)}}
+        segment_size_hls = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "hds") (ne $v nil)}}
+		hds = {{$v}}
+{{- end}}
+{{- if and (eq $k "segmentDurationHDS") (ne $v nil)}}
+        segment_duration_hds = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "segmentDurationHDSCustom") (ne $v nil)}}
+		segment_duration_hds_custom = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "segmentSizeHDS") (ne $v nil)}}
+        segment_size_hds = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "dash") (ne $v nil)}}
+		dash = {{$v}}
+{{- end}}
+{{- if and (eq $k "segmentDurationDASH") (ne $v nil)}}
+        segment_duration_dash = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "segmentDurationDASHCustom") (ne $v nil)}}
+		segment_duration_dash_custom = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "segmentSizeDASH") (ne $v nil)}}
+        segment_size_dash = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "smooth") (ne $v nil)}}
+		smooth = {{$v}}
+{{- end}}
+{{- if and (eq $k "segmentDurationSmooth") (ne $v nil)}}
+        segment_duration_smooth = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "segmentDurationSmoothCustom") (ne $v nil)}}
+		segment_duration_smooth_custom = {{$v}}
+{{- end}}
+{{- if and (eq $k "segmentSizeSmooth") (ne $v nil)}}
+        segment_size_smooth = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "contentCharacteristicsDD"}}
+content_characteristics_dd {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "objectSize") (ne $v nil)}}
+        object_size = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "popularityDistribution") (ne $v nil)}}
+        popularity_distribution = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "catalogSize") (ne $v nil)}}
+        catalog_size = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "contentType") (ne $v nil)}}
+        content_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "optimizeOption") (ne $v nil)}}
+		optimize_option = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "contentCharacteristicsWsdLargeFile"}}
+content_characteristics_wsd_large_file {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "objectSize") (ne $v nil)}}
+        object_size = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "popularityDistribution") (ne $v nil)}}
+        popularity_distribution = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "catalogSize") (ne $v nil)}}
+        catalog_size = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "contentType") (ne $v nil)}}
+        content_type = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "contentCharacteristicsWsdLive"}}
+content_characteristics_wsd_live {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "catalogSize") (ne $v nil)}}
+        catalog_size = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "contentType") (ne $v nil)}}
+        content_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "popularityDistribution") (ne $v nil)}}
+        popularity_distribution = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "hls") (ne $v nil)}}
+		hls = {{$v}}
+{{- end}}
+{{- if and (eq $k "segmentDurationHLS") (ne $v nil)}}
+        segment_duration_hls = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "segmentSizeHLS") (ne $v nil)}}
+        segment_size_hls = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "hds") (ne $v nil)}}
+		hds = {{$v}}
+{{- end}}
+{{- if and (eq $k "segmentDurationHDS") (ne $v nil)}}
+        segment_duration_hds = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "segmentSizeHDS") (ne $v nil)}}
+        segment_size_hds = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "dash") (ne $v nil)}}
+		dash = {{$v}}
+{{- end}}
+{{- if and (eq $k "segmentDurationDASH") (ne $v nil)}}
+        segment_duration_dash = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "segmentSizeDASH") (ne $v nil)}}
+        segment_size_dash = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "smooth") (ne $v nil)}}
+		smooth = {{$v}}
+{{- end}}
+{{- if and (eq $k "segmentDurationSmooth") (ne $v nil)}}
+        segment_duration_smooth = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "segmentSizeSmooth") (ne $v nil)}}
+        segment_size_smooth = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "contentCharacteristicsWsdVod"}}
+content_characteristics_wsd_vod {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "catalogSize") (ne $v nil)}}
+        catalog_size = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "contentType") (ne $v nil)}}
+        content_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "popularityDistribution") (ne $v nil)}}
+        popularity_distribution = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "hls") (ne $v nil)}}
+		hls = {{$v}}
+{{- end}}
+{{- if and (eq $k "segmentDurationHLS") (ne $v nil)}}
+        segment_duration_hls = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "segmentSizeHLS") (ne $v nil)}}
+        segment_size_hls = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "hds") (ne $v nil)}}
+		hds = {{$v}}
+{{- end}}
+{{- if and (eq $k "segmentDurationHDS") (ne $v nil)}}
+        segment_duration_hds = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "segmentSizeHDS") (ne $v nil)}}
+        segment_size_hds = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "dash") (ne $v nil)}}
+		dash = {{$v}}
+{{- end}}
+{{- if and (eq $k "segmentDurationDASH") (ne $v nil)}}
+        segment_duration_dash = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "segmentSizeDASH") (ne $v nil)}}
+        segment_size_dash = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "smooth") (ne $v nil)}}
+		smooth = {{$v}}
+{{- end}}
+{{- if and (eq $k "segmentDurationSmooth") (ne $v nil)}}
+        segment_duration_smooth = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "segmentSizeSmooth") (ne $v nil)}}
+        segment_size_smooth = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "contentPrePosition"}}
+content_pre_position {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "sourceType") (ne $v nil)}}
+        source_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "targets") (ne $v nil)}}
+        targets = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "firstLocation") (ne $v nil)}}
+        first_location = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "secondLocation") (ne $v nil)}}
+        second_location = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "contentTargetingProtection"}}
+content_targeting_protection {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "geoProtectionTitle") (ne $v nil)}}
+        geo_protection_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "enableGeoProtection") (ne $v nil)}}
+		enable_geo_protection = {{$v}}
+{{- end}}
+{{- if and (eq $k "geoProtectionMode") (ne $v nil)}}
+        geo_protection_mode = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "countries"}}
+		countries = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "regions"}}
+		regions = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "dmas"}}
+		dmas = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "overrideIPAddresses"}}
+		override_ip_addresses = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "enableGeoRedirectOnDeny") (ne $v nil)}}
+		enable_geo_redirect_on_deny = {{$v}}
+{{- end}}
+{{- if and (eq $k "geoRedirectUrl") (ne $v nil)}}
+        geo_redirect_url = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "ipProtectionTitle") (ne $v nil)}}
+        ip_protection_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "enableIPProtection") (ne $v nil)}}
+		enable_ip_protection = {{$v}}
+{{- end}}
+{{- if and (eq $k "ipProtectionMode") (ne $v nil)}}
+        ip_protection_mode = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "ipAddresses"}}
+		ip_addresses = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "enableIPRedirectOnDeny") (ne $v nil)}}
+		enable_ip_redirect_on_deny = {{$v}}
+{{- end}}
+{{- if and (eq $k "ipRedirectUrl") (ne $v nil)}}
+        ip_redirect_url = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "referrerProtectionTitle") (ne $v nil)}}
+        referrer_protection_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "enableReferrerProtection") (ne $v nil)}}
+		enable_referrer_protection = {{$v}}
+{{- end}}
+{{- if and (eq $k "referrerProtectionMode") (ne $v nil)}}
+        referrer_protection_mode = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "referrerDomains"}}
+		referrer_domains = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "enableReferrerRedirectOnDeny") (ne $v nil)}}
+		enable_referrer_redirect_on_deny = {{$v}}
+{{- end}}
+{{- if and (eq $k "referrerRedirectUrl") (ne $v nil)}}
+        referrer_redirect_url = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "corsSupport"}}
+cors_support {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "allowOrigins") (ne $v nil)}}
+        allow_origins = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "origins"}}
+		origins = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "allowCredentials") (ne $v nil)}}
+		allow_credentials = {{$v}}
+{{- end}}
+{{- if and (eq $k "allowHeaders") (ne $v nil)}}
+        allow_headers = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "headers"}}
+		headers = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "methods"}}
+		methods = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "exposeHeaders"}}
+		expose_headers = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "preflightMaxAge") (ne $v nil)}}
+        preflight_max_age = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "cpCode"}}
+cp_code {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if eq $k "value" }}
+		{{- if $v}}
+		value {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "id") (ne $v nil)}}
+		id = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "name") (ne $v nil)}}
+        name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "createdDate") (ne $v nil)}}
+		created_date = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "description") (ne $v nil)}}
+        description = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "products"}}
+		products = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "cpCodeLimits" }}
+		{{- if $v}}
+		cp_code_limits {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "currentCapacity") (ne $v nil)}}
+		current_capacity = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "limit") (ne $v nil)}}
+		limit = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "limitType") (ne $v nil)}}
+        limit_type = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "customBehavior"}}
+custom_behavior {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "behaviorId") (ne $v nil)}}
+        behavior_id = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "datastream"}}
+datastream {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "streamType") (ne $v nil)}}
+        stream_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "beaconStreamTitle") (ne $v nil)}}
+        beacon_stream_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "datastreamIds") (ne $v nil)}}
+        datastream_ids = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "logStreamTitle") (ne $v nil)}}
+        log_stream_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "logEnabled") (ne $v nil)}}
+		log_enabled = {{$v}}
+{{- end}}
+{{- if eq $k "logStreamName"}}
+		log_stream_name = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "samplingPercentage") (ne $v nil)}}
+		sampling_percentage = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "collectMidgressTraffic") (ne $v nil)}}
+		collect_midgress_traffic = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "dcp"}}
+dcp {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "namespaceId") (ne $v nil)}}
+        namespace_id = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "tlsenabled") (ne $v nil)}}
+		tlsenabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "wsenabled") (ne $v nil)}}
+		wsenabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "gwenabled") (ne $v nil)}}
+		gwenabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "anonymous") (ne $v nil)}}
+		anonymous = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "dcpAuthHMACTransformation"}}
+dcp_auth_hmac_transformation {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "hashConversionAlgorithm") (ne $v nil)}}
+        hash_conversion_algorithm = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "hashConversionKey") (ne $v nil)}}
+        hash_conversion_key = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "dcpAuthRegexTransformation"}}
+dcp_auth_regex_transformation {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "regexPattern") (ne $v nil)}}
+        regex_pattern = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "dcpAuthSubstringTransformation"}}
+dcp_auth_substring_transformation {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "substringStart") (ne $v nil)}}
+        substring_start = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "substringEnd") (ne $v nil)}}
+        substring_end = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "dcpAuthVariableExtractor"}}
+dcp_auth_variable_extractor {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "certificateField") (ne $v nil)}}
+        certificate_field = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "dcpMutualAuthProcessingVariableId") (ne $v nil)}}
+        dcp_mutual_auth_processing_variable_id = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "dcpDefaultAuthzGroups"}}
+dcp_default_authz_groups {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if eq $k "groupNames"}}
+		group_names = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "dcpDevRelations"}}
+dcp_dev_relations {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "customValues") (ne $v nil)}}
+		custom_values = {{$v}}
+{{- end}}
+{{- if and (eq $k "hostname") (ne $v nil)}}
+        hostname = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "path") (ne $v nil)}}
+        path = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "dcpRealTimeAuth"}}
+dcp_real_time_auth {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "extractNamespace") (ne $v nil)}}
+		extract_namespace = {{$v}}
+{{- end}}
+{{- if and (eq $k "namespaceClaim") (ne $v nil)}}
+        namespace_claim = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "extractJurisdiction") (ne $v nil)}}
+		extract_jurisdiction = {{$v}}
+{{- end}}
+{{- if and (eq $k "jurisdictionClaim") (ne $v nil)}}
+        jurisdiction_claim = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "extractHostname") (ne $v nil)}}
+		extract_hostname = {{$v}}
+{{- end}}
+{{- if and (eq $k "hostnameClaim") (ne $v nil)}}
+        hostname_claim = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "deliveryReceipt"}}
+delivery_receipt {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+        enabled = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "denyAccess"}}
+deny_access {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "reason") (ne $v nil)}}
+        reason = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "denyDirectFailoverAccess"}}
+deny_direct_failover_access {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+        enabled = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "deviceCharacteristicCacheId"}}
+device_characteristic_cache_id {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if eq $k "elements"}}
+		elements = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "deviceCharacteristicHeader"}}
+device_characteristic_header {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if eq $k "elements"}}
+		elements = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "dnsAsyncRefresh"}}
+dns_async_refresh {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "timeout") (ne $v nil)}}
+        timeout = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "dnsPrefresh"}}
+dns_prefresh {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "delay") (ne $v nil)}}
+        delay = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "timeout") (ne $v nil)}}
+        timeout = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "downgradeProtocol"}}
+downgrade_protocol {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "downloadCompleteMarker"}}
+download_complete_marker {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+        enabled = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "downloadNotification"}}
+download_notification {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+        enabled = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "downstreamCache"}}
+downstream_cache {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "behavior") (ne $v nil)}}
+        behavior = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "allowBehavior") (ne $v nil)}}
+        allow_behavior = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "ttl") (ne $v nil)}}
+        ttl = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "sendHeaders") (ne $v nil)}}
+        send_headers = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "sendPrivate") (ne $v nil)}}
+		send_private = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "dynamicThroughtputOptimization"}}
+dynamic_throughtput_optimization {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "dynamicThroughtputOptimizationOverride"}}
+dynamic_throughtput_optimization_override {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "throughput") (ne $v nil)}}
+        throughput = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "dynamicWebContent"}}
+dynamic_web_content {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "sureRoute") (ne $v nil)}}
+		sure_route = {{$v}}
+{{- end}}
+{{- if and (eq $k "prefetch") (ne $v nil)}}
+		prefetch = {{$v}}
+{{- end}}
+{{- if and (eq $k "realUserMonitoring") (ne $v nil)}}
+		real_user_monitoring = {{$v}}
+{{- end}}
+{{- if and (eq $k "imageCompression") (ne $v nil)}}
+		image_compression = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "earlyHints"}}
+early_hints {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "resourceUrl") (ne $v nil)}}
+        resource_url = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "ecmsBulkUpload"}}
+ecms_bulk_upload {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "ecmsDatabase"}}
+ecms_database {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "database") (ne $v nil)}}
+        database = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "extractLocation") (ne $v nil)}}
+        extract_location = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "headerName") (ne $v nil)}}
+        header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "queryParameterName") (ne $v nil)}}
+        query_parameter_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "regexPattern") (ne $v nil)}}
+        regex_pattern = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "ecmsDataset"}}
+ecms_dataset {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "dataset") (ne $v nil)}}
+        dataset = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "extractLocation") (ne $v nil)}}
+        extract_location = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "headerName") (ne $v nil)}}
+        header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "queryParameterName") (ne $v nil)}}
+        query_parameter_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "regexPattern") (ne $v nil)}}
+        regex_pattern = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "ecmsObjectKey"}}
+ecms_object_key {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "regex") (ne $v nil)}}
+        regex = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "edgeConnect"}}
+edge_connect {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "apiConnector") (ne $v nil)}}
+        api_connector = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "apiDataElements"}}
+		api_data_elements = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "destinationHostname") (ne $v nil)}}
+        destination_hostname = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "destinationPath") (ne $v nil)}}
+        destination_path = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "overrideAggregateSettings") (ne $v nil)}}
+		override_aggregate_settings = {{$v}}
+{{- end}}
+{{- if and (eq $k "aggregateTime") (ne $v nil)}}
+        aggregate_time = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "aggregateLines") (ne $v nil)}}
+        aggregate_lines = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "aggregateSize") (ne $v nil)}}
+        aggregate_size = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "edgeLoadBalancingAdvanced"}}
+edge_load_balancing_advanced {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "description") (ne $v nil)}}
+        description = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "xml") (ne $v nil)}}
+        xml = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "edgeLoadBalancingDataCenter"}}
+edge_load_balancing_data_center {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "originId") (ne $v nil)}}
+        origin_id = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "description") (ne $v nil)}}
+        description = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "hostname") (ne $v nil)}}
+        hostname = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "cookieName") (ne $v nil)}}
+        cookie_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "failoverTitle") (ne $v nil)}}
+        failover_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "enableFailover") (ne $v nil)}}
+		enable_failover = {{$v}}
+{{- end}}
+{{- if and (eq $k "ip") (ne $v nil)}}
+        ip = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "failoverRules" }}
+		{{- range $v := $v}}
+		failover_rules {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "failoverHostname") (ne $v nil)}}
+        failover_hostname = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "modifyRequest") (ne $v nil)}}
+		modify_request = {{$v}}
+{{- end}}
+{{- if and (eq $k "overrideHostname") (ne $v nil)}}
+		override_hostname = {{$v}}
+{{- end}}
+{{- if and (eq $k "contextRoot") (ne $v nil)}}
+        context_root = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "absolutePath") (ne $v nil)}}
+		absolute_path = {{$v}}
+{{- end}}
+{{- end}}
+		}
+{{- end}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "edgeLoadBalancingOrigin"}}
+edge_load_balancing_origin {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "id") (ne $v nil)}}
+        id = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "description") (ne $v nil)}}
+        description = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "hostname") (ne $v nil)}}
+        hostname = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "sessionPersistenceTitle") (ne $v nil)}}
+        session_persistence_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "enableSessionPersistence") (ne $v nil)}}
+		enable_session_persistence = {{$v}}
+{{- end}}
+{{- if and (eq $k "cookieName") (ne $v nil)}}
+        cookie_name = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "edgeOriginAuthorization"}}
+edge_origin_authorization {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "cookieName") (ne $v nil)}}
+        cookie_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "value") (ne $v nil)}}
+        value = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "domain") (ne $v nil)}}
+        domain = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "edgeRedirector"}}
+edge_redirector {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "isSharedPolicy") (ne $v nil)}}
+		is_shared_policy = {{$v}}
+{{- end}}
+{{- if eq $k "cloudletPolicy" }}
+		{{- if $v}}
+		cloudlet_policy {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "id") (ne $v nil)}}
+		id = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "name") (ne $v nil)}}
+        name = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "cloudletSharedPolicy") (ne $v nil)}}
+		cloudlet_shared_policy = {{$v | AsInt}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "edgeScape"}}
+edge_scape {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "edgeSideIncludes"}}
+edge_side_includes {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "enableViaHttp") (ne $v nil)}}
+		enable_via_http = {{$v}}
+{{- end}}
+{{- if and (eq $k "passSetCookie") (ne $v nil)}}
+		pass_set_cookie = {{$v}}
+{{- end}}
+{{- if and (eq $k "passClientIp") (ne $v nil)}}
+		pass_client_ip = {{$v}}
+{{- end}}
+{{- if and (eq $k "i18nStatus") (ne $v nil)}}
+		i18n_status = {{$v}}
+{{- end}}
+{{- if eq $k "i18nCharset"}}
+		i18n_charset = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "detectInjection") (ne $v nil)}}
+		detect_injection = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "edgeWorker"}}
+edge_worker {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "createEdgeWorker") (ne $v nil)}}
+        create_edge_worker = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "edgeWorkerId") (ne $v nil)}}
+        edge_worker_id = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "resourceTier") (ne $v nil)}}
+        resource_tier = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "mPulse") (ne $v nil)}}
+		m_pulse = {{$v}}
+{{- end}}
+{{- if and (eq $k "mPulseInformation") (ne $v nil)}}
+        m_pulse_information = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "enforceMtlsSettings"}}
+enforce_mtls_settings {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enableAuthSet") (ne $v nil)}}
+		enable_auth_set = {{$v}}
+{{- end}}
+{{- if eq $k "certificateAuthoritySet"}}
+		certificate_authority_set = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "enableOcspStatus") (ne $v nil)}}
+		enable_ocsp_status = {{$v}}
+{{- end}}
+{{- if and (eq $k "enableDenyRequest") (ne $v nil)}}
+		enable_deny_request = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "enhancedAkamaiProtocol"}}
+enhanced_akamai_protocol {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "display") (ne $v nil)}}
+        display = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "enhancedProxyDetection"}}
+enhanced_proxy_detection {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "forwardHeaderEnrichment") (ne $v nil)}}
+		forward_header_enrichment = {{$v}}
+{{- end}}
+{{- if and (eq $k "enableConfigurationMode") (ne $v nil)}}
+        enable_configuration_mode = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "bestPracticeAction") (ne $v nil)}}
+        best_practice_action = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "bestPracticeRedirecturl") (ne $v nil)}}
+        best_practice_redirecturl = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "anonymousVpn") (ne $v nil)}}
+        anonymous_vpn = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "detectAnonymousVpn") (ne $v nil)}}
+		detect_anonymous_vpn = {{$v}}
+{{- end}}
+{{- if and (eq $k "detectAnonymousVpnAction") (ne $v nil)}}
+        detect_anonymous_vpn_action = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "detectAnonymousVpnRedirecturl") (ne $v nil)}}
+        detect_anonymous_vpn_redirecturl = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "publicProxy") (ne $v nil)}}
+        public_proxy = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "detectPublicProxy") (ne $v nil)}}
+		detect_public_proxy = {{$v}}
+{{- end}}
+{{- if and (eq $k "detectPublicProxyAction") (ne $v nil)}}
+        detect_public_proxy_action = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "detectPublicProxyRedirecturl") (ne $v nil)}}
+        detect_public_proxy_redirecturl = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "torExitNode") (ne $v nil)}}
+        tor_exit_node = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "detectTorExitNode") (ne $v nil)}}
+		detect_tor_exit_node = {{$v}}
+{{- end}}
+{{- if and (eq $k "detectTorExitNodeAction") (ne $v nil)}}
+        detect_tor_exit_node_action = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "detectTorExitNodeRedirecturl") (ne $v nil)}}
+        detect_tor_exit_node_redirecturl = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "smartDNSProxy") (ne $v nil)}}
+        smart_dns_proxy = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "detectSmartDNSProxy") (ne $v nil)}}
+		detect_smart_dns_proxy = {{$v}}
+{{- end}}
+{{- if and (eq $k "detectSmartDNSProxyAction") (ne $v nil)}}
+        detect_smart_dns_proxy_action = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "detectSmartDNSProxyRedirecturl") (ne $v nil)}}
+        detect_smart_dns_proxy_redirecturl = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "hostingProvider") (ne $v nil)}}
+        hosting_provider = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "detectHostingProvider") (ne $v nil)}}
+		detect_hosting_provider = {{$v}}
+{{- end}}
+{{- if and (eq $k "detectHostingProviderAction") (ne $v nil)}}
+        detect_hosting_provider_action = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "detectHostingProviderRedirecturl") (ne $v nil)}}
+        detect_hosting_provider_redirecturl = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "vpnDataCenter") (ne $v nil)}}
+        vpn_data_center = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "detectVpnDataCenter") (ne $v nil)}}
+		detect_vpn_data_center = {{$v}}
+{{- end}}
+{{- if and (eq $k "detectVpnDataCenterAction") (ne $v nil)}}
+        detect_vpn_data_center_action = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "detectVpnDataCenterRedirecturl") (ne $v nil)}}
+        detect_vpn_data_center_redirecturl = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "residentialProxy") (ne $v nil)}}
+        residential_proxy = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "detectResidentialProxy") (ne $v nil)}}
+		detect_residential_proxy = {{$v}}
+{{- end}}
+{{- if and (eq $k "detectResidentialProxyAction") (ne $v nil)}}
+        detect_residential_proxy_action = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "detectResidentialProxyRedirecturl") (ne $v nil)}}
+        detect_residential_proxy_redirecturl = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "epdForwardHeaderEnrichment"}}
+epd_forward_header_enrichment {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "failAction"}}
+fail_action {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "actionType") (ne $v nil)}}
+        action_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "saasType") (ne $v nil)}}
+        saas_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "saasCnameEnabled") (ne $v nil)}}
+		saas_cname_enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "saasCnameLevel") (ne $v nil)}}
+		saas_cname_level = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "saasCookie") (ne $v nil)}}
+        saas_cookie = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "saasQueryString") (ne $v nil)}}
+        saas_query_string = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "saasRegex") (ne $v nil)}}
+        saas_regex = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "saasReplace") (ne $v nil)}}
+        saas_replace = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "saasSuffix") (ne $v nil)}}
+        saas_suffix = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "dynamicMethod") (ne $v nil)}}
+        dynamic_method = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "dynamicCustomPath") (ne $v nil)}}
+		dynamic_custom_path = {{$v}}
+{{- end}}
+{{- if and (eq $k "dynamicPath") (ne $v nil)}}
+        dynamic_path = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "redirectHostnameType") (ne $v nil)}}
+        redirect_hostname_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "redirectHostname") (ne $v nil)}}
+        redirect_hostname = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "redirectCustomPath") (ne $v nil)}}
+		redirect_custom_path = {{$v}}
+{{- end}}
+{{- if and (eq $k "redirectPath") (ne $v nil)}}
+        redirect_path = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "redirectMethod") (ne $v nil)}}
+		redirect_method = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "contentHostname") (ne $v nil)}}
+        content_hostname = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "contentCustomPath") (ne $v nil)}}
+		content_custom_path = {{$v}}
+{{- end}}
+{{- if and (eq $k "contentPath") (ne $v nil)}}
+        content_path = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "netStorageHostname" }}
+		{{- if $v}}
+		net_storage_hostname {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "cpCode") (ne $v nil)}}
+		cp_code = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "downloadDomainName") (ne $v nil)}}
+        download_domain_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "g2oToken") (ne $v nil)}}
+        g2o_token = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "netStoragePath") (ne $v nil)}}
+        net_storage_path = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "cexHostname") (ne $v nil)}}
+        cex_hostname = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "cexCustomPath") (ne $v nil)}}
+		cex_custom_path = {{$v}}
+{{- end}}
+{{- if and (eq $k "cexPath") (ne $v nil)}}
+        cex_path = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "cpCode" }}
+		{{- if $v}}
+		cp_code {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "id") (ne $v nil)}}
+		id = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "name") (ne $v nil)}}
+        name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "createdDate") (ne $v nil)}}
+		created_date = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "description") (ne $v nil)}}
+        description = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "products"}}
+		products = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "cpCodeLimits" }}
+		{{- if $v}}
+		cp_code_limits {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "currentCapacity") (ne $v nil)}}
+		current_capacity = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "limit") (ne $v nil)}}
+		limit = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "limitType") (ne $v nil)}}
+        limit_type = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "statusCode") (ne $v nil)}}
+		status_code = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "preserveQueryString") (ne $v nil)}}
+		preserve_query_string = {{$v}}
+{{- end}}
+{{- if and (eq $k "modifyProtocol") (ne $v nil)}}
+		modify_protocol = {{$v}}
+{{- end}}
+{{- if and (eq $k "protocol") (ne $v nil)}}
+        protocol = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "allowFCMParentOverride") (ne $v nil)}}
+		allow_fcm_parent_override = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "failoverBotManagerFeatureCompatibility"}}
+failover_bot_manager_feature_compatibility {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "compatibility") (ne $v nil)}}
+		compatibility = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "fastInvalidate"}}
+fast_invalidate {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "fips"}}
+fips {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enable") (ne $v nil)}}
+		enable = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "firstPartyMarketing"}}
+first_party_marketing {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "javaScriptInsertionRule") (ne $v nil)}}
+        java_script_insertion_rule = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "cloudletPolicy" }}
+		{{- if $v}}
+		cloudlet_policy {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "id") (ne $v nil)}}
+		id = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "name") (ne $v nil)}}
+        name = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "mediaMathPrefix") (ne $v nil)}}
+        media_math_prefix = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "firstPartyMarketingPlus"}}
+first_party_marketing_plus {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "javaScriptInsertionRule") (ne $v nil)}}
+        java_script_insertion_rule = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "cloudletPolicy" }}
+		{{- if $v}}
+		cloudlet_policy {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "id") (ne $v nil)}}
+		id = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "name") (ne $v nil)}}
+        name = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "mediaMathPrefix") (ne $v nil)}}
+        media_math_prefix = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "forwardRewrite"}}
+forward_rewrite {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "isSharedPolicy") (ne $v nil)}}
+		is_shared_policy = {{$v}}
+{{- end}}
+{{- if eq $k "cloudletPolicy" }}
+		{{- if $v}}
+		cloudlet_policy {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "id") (ne $v nil)}}
+		id = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "name") (ne $v nil)}}
+        name = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "cloudletSharedPolicy") (ne $v nil)}}
+		cloudlet_shared_policy = {{$v | AsInt}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "g2oheader"}}
+g2oheader {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "dataHeader") (ne $v nil)}}
+        data_header = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "signedHeader") (ne $v nil)}}
+        signed_header = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "encodingVersion") (ne $v nil)}}
+		encoding_version = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "useCustomSignString") (ne $v nil)}}
+		use_custom_sign_string = {{$v}}
+{{- end}}
+{{- if eq $k "customSignString"}}
+		custom_sign_string = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "secretKey") (ne $v nil)}}
+        secret_key = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "nonce") (ne $v nil)}}
+        nonce = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "globalRequestNumber"}}
+global_request_number {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "outputOption") (ne $v nil)}}
+        output_option = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "headerName") (ne $v nil)}}
+        header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "variableName") (ne $v nil)}}
+        variable_name = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "graphqlCaching"}}
+graphql_caching {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "cacheResponsesWithErrors") (ne $v nil)}}
+		cache_responses_with_errors = {{$v}}
+{{- end}}
+{{- if and (eq $k "advanced") (ne $v nil)}}
+        advanced = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "postRequestProcessingErrorHandling") (ne $v nil)}}
+        post_request_processing_error_handling = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "operationsUrlQueryParameterName") (ne $v nil)}}
+        operations_url_query_parameter_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "operationsJsonBodyParameterName") (ne $v nil)}}
+        operations_json_body_parameter_name = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "gzipResponse"}}
+gzip_response {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "behavior") (ne $v nil)}}
+        behavior = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "hdDataAdvanced"}}
+hd_data_advanced {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "description") (ne $v nil)}}
+        description = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "xml") (ne $v nil)}}
+        xml = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "healthDetection"}}
+health_detection {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "retryCount") (ne $v nil)}}
+		retry_count = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "retryInterval") (ne $v nil)}}
+        retry_interval = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "maximumReconnects") (ne $v nil)}}
+		maximum_reconnects = {{$v | AsInt}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "hsafEipBinding"}}
+hsaf_eip_binding {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "customExtractedSerial") (ne $v nil)}}
+		custom_extracted_serial = {{$v}}
+{{- end}}
+{{- if and (eq $k "hashMinValue") (ne $v nil)}}
+		hash_min_value = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "hashMaxValue") (ne $v nil)}}
+		hash_max_value = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "tier") (ne $v nil)}}
+        tier = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "http2"}}
+http2 {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+        enabled = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "http3"}}
+http3 {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enable") (ne $v nil)}}
+		enable = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "httpStrictTransportSecurity"}}
+http_strict_transport_security {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enable") (ne $v nil)}}
+		enable = {{$v}}
+{{- end}}
+{{- if and (eq $k "maxAge") (ne $v nil)}}
+        max_age = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "includeSubDomains") (ne $v nil)}}
+		include_sub_domains = {{$v}}
+{{- end}}
+{{- if and (eq $k "preload") (ne $v nil)}}
+		preload = {{$v}}
+{{- end}}
+{{- if and (eq $k "redirect") (ne $v nil)}}
+		redirect = {{$v}}
+{{- end}}
+{{- if and (eq $k "redirectStatusCode") (ne $v nil)}}
+		redirect_status_code = {{$v | AsInt}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "httpToHttpsUpgrade"}}
+http_to_https_upgrade {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "upgrade") (ne $v nil)}}
+        upgrade = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "imOverride"}}
+im_override {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "override") (ne $v nil)}}
+        override = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "typesel") (ne $v nil)}}
+        typesel = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "formatvar") (ne $v nil)}}
+        formatvar = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "format") (ne $v nil)}}
+        format = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "dprvar") (ne $v nil)}}
+        dprvar = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "dpr") (ne $v nil)}}
+		dpr = {{$v}}
+{{- end}}
+{{- if and (eq $k "widthvar") (ne $v nil)}}
+        widthvar = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "width") (ne $v nil)}}
+		width = {{$v}}
+{{- end}}
+{{- if and (eq $k "policyvar") (ne $v nil)}}
+        policyvar = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "policy") (ne $v nil)}}
+        policy = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "policyvarName") (ne $v nil)}}
+        policyvar_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "policyvarIMvar") (ne $v nil)}}
+        policyvar_i_mvar = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "excludeAllQueryParameters") (ne $v nil)}}
+		exclude_all_query_parameters = {{$v}}
+{{- end}}
+{{- if eq $k "excludedQueryParameters"}}
+		excluded_query_parameters = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "imageAndVideoManager"}}
+image_and_video_manager {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "policySetType") (ne $v nil)}}
+        policy_set_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "resize") (ne $v nil)}}
+		resize = {{$v}}
+{{- end}}
+{{- if and (eq $k "applyBestFileType") (ne $v nil)}}
+		apply_best_file_type = {{$v}}
+{{- end}}
+{{- if eq $k "cpCodeOriginal" }}
+		{{- if $v}}
+		cp_code_original {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "id") (ne $v nil)}}
+		id = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "name") (ne $v nil)}}
+        name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "createdDate") (ne $v nil)}}
+		created_date = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "description") (ne $v nil)}}
+        description = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "products"}}
+		products = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "cpCodeLimits" }}
+		{{- if $v}}
+		cp_code_limits {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "currentCapacity") (ne $v nil)}}
+		current_capacity = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "limit") (ne $v nil)}}
+		limit = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "limitType") (ne $v nil)}}
+        limit_type = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if eq $k "cpCodeTransformed" }}
+		{{- if $v}}
+		cp_code_transformed {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "id") (ne $v nil)}}
+		id = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "name") (ne $v nil)}}
+        name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "createdDate") (ne $v nil)}}
+		created_date = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "description") (ne $v nil)}}
+        description = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "products"}}
+		products = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "cpCodeLimits" }}
+		{{- if $v}}
+		cp_code_limits {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "currentCapacity") (ne $v nil)}}
+		current_capacity = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "limit") (ne $v nil)}}
+		limit = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "limitType") (ne $v nil)}}
+        limit_type = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "imageSet") (ne $v nil)}}
+        image_set = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "videoSet") (ne $v nil)}}
+        video_set = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "imageManager"}}
+image_manager {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "settingsTitle") (ne $v nil)}}
+        settings_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "resize") (ne $v nil)}}
+		resize = {{$v}}
+{{- end}}
+{{- if and (eq $k "applyBestFileType") (ne $v nil)}}
+		apply_best_file_type = {{$v}}
+{{- end}}
+{{- if and (eq $k "superCacheRegion") (ne $v nil)}}
+        super_cache_region = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "trafficTitle") (ne $v nil)}}
+        traffic_title = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "cpCodeOriginal" }}
+		{{- if $v}}
+		cp_code_original {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "id") (ne $v nil)}}
+		id = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "name") (ne $v nil)}}
+        name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "createdDate") (ne $v nil)}}
+		created_date = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "description") (ne $v nil)}}
+        description = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "products"}}
+		products = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "cpCodeLimits" }}
+		{{- if $v}}
+		cp_code_limits {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "currentCapacity") (ne $v nil)}}
+		current_capacity = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "limit") (ne $v nil)}}
+		limit = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "limitType") (ne $v nil)}}
+        limit_type = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if eq $k "cpCodeTransformed" }}
+		{{- if $v}}
+		cp_code_transformed {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "id") (ne $v nil)}}
+		id = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "name") (ne $v nil)}}
+        name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "createdDate") (ne $v nil)}}
+		created_date = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "description") (ne $v nil)}}
+        description = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "products"}}
+		products = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "cpCodeLimits" }}
+		{{- if $v}}
+		cp_code_limits {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "currentCapacity") (ne $v nil)}}
+		current_capacity = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "limit") (ne $v nil)}}
+		limit = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "limitType") (ne $v nil)}}
+        limit_type = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "apiReferenceTitle") (ne $v nil)}}
+        api_reference_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "useExistingPolicySet") (ne $v nil)}}
+		use_existing_policy_set = {{$v}}
+{{- end}}
+{{- if and (eq $k "policySet") (ne $v nil)}}
+        policy_set = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "advanced") (ne $v nil)}}
+		advanced = {{$v}}
+{{- end}}
+{{- if and (eq $k "policyToken") (ne $v nil)}}
+        policy_token = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "policyTokenDefault") (ne $v nil)}}
+        policy_token_default = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "imageManagerVideo"}}
+image_manager_video {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "settingsTitle") (ne $v nil)}}
+        settings_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "resize") (ne $v nil)}}
+		resize = {{$v}}
+{{- end}}
+{{- if and (eq $k "applyBestFileType") (ne $v nil)}}
+		apply_best_file_type = {{$v}}
+{{- end}}
+{{- if and (eq $k "superCacheRegion") (ne $v nil)}}
+        super_cache_region = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "trafficTitle") (ne $v nil)}}
+        traffic_title = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "cpCodeOriginal" }}
+		{{- if $v}}
+		cp_code_original {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "id") (ne $v nil)}}
+		id = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "name") (ne $v nil)}}
+        name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "createdDate") (ne $v nil)}}
+		created_date = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "description") (ne $v nil)}}
+        description = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "products"}}
+		products = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "cpCodeLimits" }}
+		{{- if $v}}
+		cp_code_limits {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "currentCapacity") (ne $v nil)}}
+		current_capacity = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "limit") (ne $v nil)}}
+		limit = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "limitType") (ne $v nil)}}
+        limit_type = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if eq $k "cpCodeTransformed" }}
+		{{- if $v}}
+		cp_code_transformed {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "id") (ne $v nil)}}
+		id = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "name") (ne $v nil)}}
+        name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "createdDate") (ne $v nil)}}
+		created_date = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "description") (ne $v nil)}}
+        description = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "products"}}
+		products = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "cpCodeLimits" }}
+		{{- if $v}}
+		cp_code_limits {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "currentCapacity") (ne $v nil)}}
+		current_capacity = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "limit") (ne $v nil)}}
+		limit = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "limitType") (ne $v nil)}}
+        limit_type = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "apiReferenceTitle") (ne $v nil)}}
+        api_reference_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "useExistingPolicySet") (ne $v nil)}}
+		use_existing_policy_set = {{$v}}
+{{- end}}
+{{- if and (eq $k "policySet") (ne $v nil)}}
+        policy_set = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "advanced") (ne $v nil)}}
+		advanced = {{$v}}
+{{- end}}
+{{- if and (eq $k "policyToken") (ne $v nil)}}
+        policy_token = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "policyTokenDefault") (ne $v nil)}}
+        policy_token_default = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "include"}}
+include {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "id") (ne $v nil)}}
+        id = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "instant"}}
+instant {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "prefetchCacheable") (ne $v nil)}}
+		prefetch_cacheable = {{$v}}
+{{- end}}
+{{- if and (eq $k "prefetchNoStore") (ne $v nil)}}
+		prefetch_no_store = {{$v}}
+{{- end}}
+{{- if eq $k "prefetchNoStoreExtensions"}}
+		prefetch_no_store_extensions = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "prefetchHtml") (ne $v nil)}}
+		prefetch_html = {{$v}}
+{{- end}}
+{{- if eq $k "customLinkRelations"}}
+		custom_link_relations = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "instantConfig"}}
+instant_config {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "largeFileOptimization"}}
+large_file_optimization {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "enablePartialObjectCaching") (ne $v nil)}}
+        enable_partial_object_caching = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "minimumSize") (ne $v nil)}}
+        minimum_size = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "maximumSize") (ne $v nil)}}
+        maximum_size = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "useVersioning") (ne $v nil)}}
+		use_versioning = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "largeFileOptimizationAdvanced"}}
+large_file_optimization_advanced {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "objectSize") (ne $v nil)}}
+        object_size = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "fragmentSize") (ne $v nil)}}
+        fragment_size = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "prefetchDuringRequest") (ne $v nil)}}
+		prefetch_during_request = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "prefetchAfterRequest") (ne $v nil)}}
+		prefetch_after_request = {{$v | AsInt}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "limitBitRate"}}
+limit_bit_rate {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if eq $k "bitrateTable" }}
+		{{- range $v := $v}}
+		bitrate_table {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "bitrateValue") (ne $v nil)}}
+		bitrate_value = {{$v}}
+{{- end}}
+{{- if and (eq $k "bitrateUnit") (ne $v nil)}}
+        bitrate_unit = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+{{- end}}
+{{- end}}
+{{- if eq $k "thresholdTable" }}
+		{{- range $v := $v}}
+		threshold_table {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "thresholdValue") (ne $v nil)}}
+		threshold_value = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "thresholdUnit") (ne $v nil)}}
+        threshold_unit = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+{{- end}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "logCustom"}}
+log_custom {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "logCustomLogField") (ne $v nil)}}
+		log_custom_log_field = {{$v}}
+{{- end}}
+{{- if and (eq $k "customLogField") (ne $v nil)}}
+        custom_log_field = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "mPulse"}}
+m_pulse {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "requirePci") (ne $v nil)}}
+		require_pci = {{$v}}
+{{- end}}
+{{- if and (eq $k "loaderVersion") (ne $v nil)}}
+        loader_version = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "titleOptional") (ne $v nil)}}
+        title_optional = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "apiKey") (ne $v nil)}}
+        api_key = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "bufferSize") (ne $v nil)}}
+        buffer_size = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "configOverride") (ne $v nil)}}
+        config_override = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "manifestPersonalization"}}
+manifest_personalization {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "hlsTitle") (ne $v nil)}}
+        hls_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "hlsEnabled") (ne $v nil)}}
+		hls_enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "hlsMode") (ne $v nil)}}
+        hls_mode = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "hlsPreferredBitrate") (ne $v nil)}}
+        hls_preferred_bitrate = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "hlsFilterInBitrates") (ne $v nil)}}
+        hls_filter_in_bitrates = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "hlsFilterInBitrateRanges") (ne $v nil)}}
+        hls_filter_in_bitrate_ranges = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "hlsQueryParamEnabled") (ne $v nil)}}
+		hls_query_param_enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "hlsQueryParamSecretKey") (ne $v nil)}}
+        hls_query_param_secret_key = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "hlsQueryParamTransitionKey") (ne $v nil)}}
+        hls_query_param_transition_key = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "hlsShowAdvanced") (ne $v nil)}}
+		hls_show_advanced = {{$v}}
+{{- end}}
+{{- if and (eq $k "hlsEnableDebugHeaders") (ne $v nil)}}
+		hls_enable_debug_headers = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "manifestRerouting"}}
+manifest_rerouting {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "partner") (ne $v nil)}}
+        partner = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "username") (ne $v nil)}}
+        username = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "manualServerPush"}}
+manual_server_push {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if eq $k "serverpushlist"}}
+		serverpushlist = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "mediaAcceleration"}}
+media_acceleration {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "mediaAccelerationQuicOptout"}}
+media_acceleration_quic_optout {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "optout") (ne $v nil)}}
+        optout = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "mediaClient"}}
+media_client {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "beaconId") (ne $v nil)}}
+        beacon_id = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "useHybridHttpUdp") (ne $v nil)}}
+		use_hybrid_http_udp = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "mediaFileRetrievalOptimization"}}
+media_file_retrieval_optimization {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "mediaOriginFailover"}}
+media_origin_failover {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "detectOriginUnresponsiveTitle") (ne $v nil)}}
+        detect_origin_unresponsive_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "detectOriginUnresponsive") (ne $v nil)}}
+		detect_origin_unresponsive = {{$v}}
+{{- end}}
+{{- if and (eq $k "originUnresponsiveDetectionLevel") (ne $v nil)}}
+        origin_unresponsive_detection_level = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "originUnresponsiveBlacklistOriginIp") (ne $v nil)}}
+		origin_unresponsive_blacklist_origin_ip = {{$v}}
+{{- end}}
+{{- if and (eq $k "originUnresponsiveBlacklistWindow") (ne $v nil)}}
+        origin_unresponsive_blacklist_window = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "originUnresponsiveRecovery") (ne $v nil)}}
+        origin_unresponsive_recovery = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "originUnresponsiveRetryLimit") (ne $v nil)}}
+        origin_unresponsive_retry_limit = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "originUnresponsiveBackupHost") (ne $v nil)}}
+        origin_unresponsive_backup_host = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "originUnresponsiveAlternateHost") (ne $v nil)}}
+        origin_unresponsive_alternate_host = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "originUnresponsiveModifyRequestPath") (ne $v nil)}}
+		origin_unresponsive_modify_request_path = {{$v}}
+{{- end}}
+{{- if and (eq $k "originUnresponsiveModifiedPath") (ne $v nil)}}
+        origin_unresponsive_modified_path = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "originUnresponsiveIncludeQueryString") (ne $v nil)}}
+		origin_unresponsive_include_query_string = {{$v}}
+{{- end}}
+{{- if and (eq $k "originUnresponsiveRedirectMethod") (ne $v nil)}}
+		origin_unresponsive_redirect_method = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "originUnresponsiveChangeProtocol") (ne $v nil)}}
+		origin_unresponsive_change_protocol = {{$v}}
+{{- end}}
+{{- if and (eq $k "originUnresponsiveProtocol") (ne $v nil)}}
+        origin_unresponsive_protocol = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "detectOriginUnavailableTitle") (ne $v nil)}}
+        detect_origin_unavailable_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "detectOriginUnavailable") (ne $v nil)}}
+		detect_origin_unavailable = {{$v}}
+{{- end}}
+{{- if and (eq $k "originUnavailableDetectionLevel") (ne $v nil)}}
+        origin_unavailable_detection_level = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "originUnavailableResponseCodes"}}
+		origin_unavailable_response_codes = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "originUnavailableBlacklistOriginIp") (ne $v nil)}}
+		origin_unavailable_blacklist_origin_ip = {{$v}}
+{{- end}}
+{{- if and (eq $k "originUnavailableBlacklistWindow") (ne $v nil)}}
+        origin_unavailable_blacklist_window = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "originUnavailableRecovery") (ne $v nil)}}
+        origin_unavailable_recovery = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "originUnavailableRetryLimit") (ne $v nil)}}
+        origin_unavailable_retry_limit = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "originUnavailableBackupHost") (ne $v nil)}}
+        origin_unavailable_backup_host = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "originUnavailableAlternateHost") (ne $v nil)}}
+        origin_unavailable_alternate_host = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "originUnavailableModifyRequestPath") (ne $v nil)}}
+		origin_unavailable_modify_request_path = {{$v}}
+{{- end}}
+{{- if and (eq $k "originUnavailableModifiedPath") (ne $v nil)}}
+        origin_unavailable_modified_path = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "originUnavailableIncludeQueryString") (ne $v nil)}}
+		origin_unavailable_include_query_string = {{$v}}
+{{- end}}
+{{- if and (eq $k "originUnavailableRedirectMethod") (ne $v nil)}}
+		origin_unavailable_redirect_method = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "originUnavailableChangeProtocol") (ne $v nil)}}
+		origin_unavailable_change_protocol = {{$v}}
+{{- end}}
+{{- if and (eq $k "originUnavailableProtocol") (ne $v nil)}}
+        origin_unavailable_protocol = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "detectObjectUnavailableTitle") (ne $v nil)}}
+        detect_object_unavailable_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "detectObjectUnavailable") (ne $v nil)}}
+		detect_object_unavailable = {{$v}}
+{{- end}}
+{{- if and (eq $k "objectUnavailableDetectionLevel") (ne $v nil)}}
+        object_unavailable_detection_level = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "objectUnavailableResponseCodes"}}
+		object_unavailable_response_codes = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "objectUnavailableBlacklistOriginIp") (ne $v nil)}}
+		object_unavailable_blacklist_origin_ip = {{$v}}
+{{- end}}
+{{- if and (eq $k "objectUnavailableBlacklistWindow") (ne $v nil)}}
+        object_unavailable_blacklist_window = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "objectUnavailableRecovery") (ne $v nil)}}
+        object_unavailable_recovery = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "objectUnavailableRetryLimit") (ne $v nil)}}
+        object_unavailable_retry_limit = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "objectUnavailableBackupHost") (ne $v nil)}}
+        object_unavailable_backup_host = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "objectUnavailableAlternateHost") (ne $v nil)}}
+        object_unavailable_alternate_host = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "objectUnavailableModifyRequestPath") (ne $v nil)}}
+		object_unavailable_modify_request_path = {{$v}}
+{{- end}}
+{{- if and (eq $k "objectUnavailableModifiedPath") (ne $v nil)}}
+        object_unavailable_modified_path = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "objectUnavailableIncludeQueryString") (ne $v nil)}}
+		object_unavailable_include_query_string = {{$v}}
+{{- end}}
+{{- if and (eq $k "objectUnavailableRedirectMethod") (ne $v nil)}}
+		object_unavailable_redirect_method = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "objectUnavailableChangeProtocol") (ne $v nil)}}
+		object_unavailable_change_protocol = {{$v}}
+{{- end}}
+{{- if and (eq $k "objectUnavailableProtocol") (ne $v nil)}}
+        object_unavailable_protocol = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "otherOptions") (ne $v nil)}}
+        other_options = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "clientResponseCode") (ne $v nil)}}
+        client_response_code = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "cacheErrorResponse") (ne $v nil)}}
+		cache_error_response = {{$v}}
+{{- end}}
+{{- if and (eq $k "cacheWindow") (ne $v nil)}}
+        cache_window = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "metadataCaching"}}
+metadata_caching {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "mobileSdkPerformance"}}
+mobile_sdk_performance {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "secondaryMultipathToOrigin") (ne $v nil)}}
+		secondary_multipath_to_origin = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "modifyIncomingRequestHeader"}}
+modify_incoming_request_header {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "action") (ne $v nil)}}
+        action = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "standardAddHeaderName") (ne $v nil)}}
+        standard_add_header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "standardDeleteHeaderName") (ne $v nil)}}
+        standard_delete_header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "standardModifyHeaderName") (ne $v nil)}}
+        standard_modify_header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "standardPassHeaderName") (ne $v nil)}}
+        standard_pass_header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "customHeaderName") (ne $v nil)}}
+        custom_header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "headerValue") (ne $v nil)}}
+        header_value = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "newHeaderValue") (ne $v nil)}}
+        new_header_value = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "avoidDuplicateHeaders") (ne $v nil)}}
+		avoid_duplicate_headers = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "modifyIncomingResponseHeader"}}
+modify_incoming_response_header {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "action") (ne $v nil)}}
+        action = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "standardAddHeaderName") (ne $v nil)}}
+        standard_add_header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "standardDeleteHeaderName") (ne $v nil)}}
+        standard_delete_header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "standardModifyHeaderName") (ne $v nil)}}
+        standard_modify_header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "standardPassHeaderName") (ne $v nil)}}
+        standard_pass_header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "customHeaderName") (ne $v nil)}}
+        custom_header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "headerValue") (ne $v nil)}}
+        header_value = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "newHeaderValue") (ne $v nil)}}
+        new_header_value = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "avoidDuplicateHeaders") (ne $v nil)}}
+		avoid_duplicate_headers = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "modifyOutgoingRequestHeader"}}
+modify_outgoing_request_header {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "action") (ne $v nil)}}
+        action = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "standardAddHeaderName") (ne $v nil)}}
+        standard_add_header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "standardDeleteHeaderName") (ne $v nil)}}
+        standard_delete_header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "standardModifyHeaderName") (ne $v nil)}}
+        standard_modify_header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "customHeaderName") (ne $v nil)}}
+        custom_header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "headerValue") (ne $v nil)}}
+        header_value = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "newHeaderValue") (ne $v nil)}}
+        new_header_value = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "regexHeaderMatch") (ne $v nil)}}
+        regex_header_match = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "regexHeaderReplace") (ne $v nil)}}
+        regex_header_replace = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "matchMultiple") (ne $v nil)}}
+		match_multiple = {{$v}}
+{{- end}}
+{{- if and (eq $k "avoidDuplicateHeaders") (ne $v nil)}}
+		avoid_duplicate_headers = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "modifyOutgoingResponseHeader"}}
+modify_outgoing_response_header {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "action") (ne $v nil)}}
+        action = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "standardAddHeaderName") (ne $v nil)}}
+        standard_add_header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "standardDeleteHeaderName") (ne $v nil)}}
+        standard_delete_header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "standardModifyHeaderName") (ne $v nil)}}
+        standard_modify_header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "customHeaderName") (ne $v nil)}}
+        custom_header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "headerValue") (ne $v nil)}}
+        header_value = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "newHeaderValue") (ne $v nil)}}
+        new_header_value = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "regexHeaderMatch") (ne $v nil)}}
+        regex_header_match = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "regexHeaderReplace") (ne $v nil)}}
+        regex_header_replace = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "matchMultiple") (ne $v nil)}}
+		match_multiple = {{$v}}
+{{- end}}
+{{- if and (eq $k "avoidDuplicateHeaders") (ne $v nil)}}
+		avoid_duplicate_headers = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "modifyViaHeader"}}
+modify_via_header {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "modificationOption") (ne $v nil)}}
+        modification_option = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "renameHeaderTo") (ne $v nil)}}
+        rename_header_to = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "origin"}}
+origin {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "originType") (ne $v nil)}}
+        origin_type = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "netStorage" }}
+		{{- if $v}}
+		net_storage {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "cpCode") (ne $v nil)}}
+		cp_code = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "downloadDomainName") (ne $v nil)}}
+        download_domain_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "g2oToken") (ne $v nil)}}
+        g2o_token = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "originId") (ne $v nil)}}
+        origin_id = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "hostname") (ne $v nil)}}
+        hostname = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "secondHostnameEnabled") (ne $v nil)}}
+		second_hostname_enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "secondHostname") (ne $v nil)}}
+        second_hostname = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "mslorigin") (ne $v nil)}}
+        mslorigin = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "saasType") (ne $v nil)}}
+        saas_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "saasCnameEnabled") (ne $v nil)}}
+		saas_cname_enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "saasCnameLevel") (ne $v nil)}}
+		saas_cname_level = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "saasCookie") (ne $v nil)}}
+        saas_cookie = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "saasQueryString") (ne $v nil)}}
+        saas_query_string = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "saasRegex") (ne $v nil)}}
+        saas_regex = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "saasReplace") (ne $v nil)}}
+        saas_replace = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "saasSuffix") (ne $v nil)}}
+        saas_suffix = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "forwardHostHeader") (ne $v nil)}}
+        forward_host_header = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "customForwardHostHeader") (ne $v nil)}}
+        custom_forward_host_header = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "cacheKeyHostname") (ne $v nil)}}
+        cache_key_hostname = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "ipVersion") (ne $v nil)}}
+        ip_version = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "useUniqueCacheKey") (ne $v nil)}}
+		use_unique_cache_key = {{$v}}
+{{- end}}
+{{- if and (eq $k "compress") (ne $v nil)}}
+		compress = {{$v}}
+{{- end}}
+{{- if and (eq $k "enableTrueClientIp") (ne $v nil)}}
+		enable_true_client_ip = {{$v}}
+{{- end}}
+{{- if and (eq $k "trueClientIpHeader") (ne $v nil)}}
+        true_client_ip_header = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "trueClientIpClientSetting") (ne $v nil)}}
+		true_client_ip_client_setting = {{$v}}
+{{- end}}
+{{- if and (eq $k "originCertificate") (ne $v nil)}}
+        origin_certificate = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "verificationMode") (ne $v nil)}}
+        verification_mode = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "originSni") (ne $v nil)}}
+		origin_sni = {{$v}}
+{{- end}}
+{{- if eq $k "customValidCnValues"}}
+		custom_valid_cn_values = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "originCertsToHonor") (ne $v nil)}}
+        origin_certs_to_honor = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "standardCertificateAuthorities"}}
+		standard_certificate_authorities = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "customCertificateAuthorities" }}
+		{{- range $v := $v}}
+		custom_certificate_authorities {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "subjectCN") (ne $v nil)}}
+        subject_cn = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "subjectAlternativeNames"}}
+		subject_alternative_names = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "subjectRDNs" }}
+		{{- if $v}}
+		subject_rdns {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "C") (ne $v nil)}}
+        c = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "OU") (ne $v nil)}}
+        ou = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "O") (ne $v nil)}}
+        o = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "CN") (ne $v nil)}}
+        cn = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if eq $k "issuerRDNs" }}
+		{{- if $v}}
+		issuer_rdns {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "C") (ne $v nil)}}
+        c = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "OU") (ne $v nil)}}
+        ou = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "O") (ne $v nil)}}
+        o = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "CN") (ne $v nil)}}
+        cn = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "notBefore") (ne $v nil)}}
+		not_before = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "notAfter") (ne $v nil)}}
+		not_after = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "sigAlgName") (ne $v nil)}}
+        sig_alg_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "publicKey") (ne $v nil)}}
+        public_key = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "publicKeyAlgorithm") (ne $v nil)}}
+        public_key_algorithm = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "publicKeyFormat") (ne $v nil)}}
+        public_key_format = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "serialNumber") (ne $v nil)}}
+		serial_number = "{{$v}}"
+{{- end}}
+{{- if and (eq $k "version") (ne $v nil)}}
+		version = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "sha1Fingerprint") (ne $v nil)}}
+        sha1_fingerprint = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "pemEncodedCert") (ne $v nil)}}
+        pem_encoded_cert = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "canBeLeaf") (ne $v nil)}}
+		can_be_leaf = {{$v}}
+{{- end}}
+{{- if and (eq $k "canBeCA") (ne $v nil)}}
+		can_be_ca = {{$v}}
+{{- end}}
+{{- if and (eq $k "selfSigned") (ne $v nil)}}
+		self_signed = {{$v}}
+{{- end}}
+{{- end}}
+		}
+{{- end}}
+	{{- if (eq (len $v) 0)}}
+		custom_certificate_authorities {}
+	{{- end}}
+{{- end}}
+{{- if eq $k "customCertificates" }}
+		{{- range $v := $v}}
+		custom_certificates {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "subjectCN") (ne $v nil)}}
+        subject_cn = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "subjectAlternativeNames"}}
+		subject_alternative_names = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "subjectRDNs" }}
+		{{- if $v}}
+		subject_rdns {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "C") (ne $v nil)}}
+        c = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "OU") (ne $v nil)}}
+        ou = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "O") (ne $v nil)}}
+        o = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "CN") (ne $v nil)}}
+        cn = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if eq $k "issuerRDNs" }}
+		{{- if $v}}
+		issuer_rdns {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "C") (ne $v nil)}}
+        c = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "OU") (ne $v nil)}}
+        ou = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "O") (ne $v nil)}}
+        o = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "CN") (ne $v nil)}}
+        cn = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "notBefore") (ne $v nil)}}
+		not_before = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "notAfter") (ne $v nil)}}
+		not_after = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "sigAlgName") (ne $v nil)}}
+        sig_alg_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "publicKey") (ne $v nil)}}
+        public_key = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "publicKeyAlgorithm") (ne $v nil)}}
+        public_key_algorithm = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "publicKeyFormat") (ne $v nil)}}
+        public_key_format = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "serialNumber") (ne $v nil)}}
+		serial_number = "{{$v}}"
+{{- end}}
+{{- if and (eq $k "version") (ne $v nil)}}
+		version = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "sha1Fingerprint") (ne $v nil)}}
+        sha1_fingerprint = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "pemEncodedCert") (ne $v nil)}}
+        pem_encoded_cert = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "canBeLeaf") (ne $v nil)}}
+		can_be_leaf = {{$v}}
+{{- end}}
+{{- if and (eq $k "canBeCA") (ne $v nil)}}
+		can_be_ca = {{$v}}
+{{- end}}
+{{- if and (eq $k "selfSigned") (ne $v nil)}}
+		self_signed = {{$v}}
+{{- end}}
+{{- end}}
+		}
+{{- end}}
+	{{- if (eq (len $v) 0)}}
+		custom_certificates {}
+	{{- end}}
+{{- end}}
+{{- if and (eq $k "ports") (ne $v nil)}}
+        ports = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "httpPort") (ne $v nil)}}
+		http_port = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "httpsPort") (ne $v nil)}}
+		https_port = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "tlsVersionTitle") (ne $v nil)}}
+        tls_version_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "minTlsVersion") (ne $v nil)}}
+        min_tls_version = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "maxTlsVersion") (ne $v nil)}}
+        max_tls_version = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "originCharacteristics"}}
+origin_characteristics {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "authenticationMethodTitle") (ne $v nil)}}
+        authentication_method_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "authenticationMethod") (ne $v nil)}}
+        authentication_method = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "encodingVersion") (ne $v nil)}}
+		encoding_version = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "useCustomSignString") (ne $v nil)}}
+		use_custom_sign_string = {{$v}}
+{{- end}}
+{{- if eq $k "customSignString"}}
+		custom_sign_string = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "secretKey") (ne $v nil)}}
+        secret_key = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "nonce") (ne $v nil)}}
+        nonce = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "mslkey") (ne $v nil)}}
+        mslkey = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "mslname") (ne $v nil)}}
+        mslname = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "accessKeyEncryptedStorage") (ne $v nil)}}
+		access_key_encrypted_storage = {{$v}}
+{{- end}}
+{{- if and (eq $k "gcsAccessKeyVersionGuid") (ne $v nil)}}
+        gcs_access_key_version_guid = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "gcsHmacKeyAccessId") (ne $v nil)}}
+        gcs_hmac_key_access_id = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "gcsHmacKeySecret") (ne $v nil)}}
+        gcs_hmac_key_secret = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "awsAccessKeyVersionGuid") (ne $v nil)}}
+        aws_access_key_version_guid = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "awsAccessKeyId") (ne $v nil)}}
+        aws_access_key_id = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "awsSecretAccessKey") (ne $v nil)}}
+        aws_secret_access_key = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "awsRegion") (ne $v nil)}}
+        aws_region = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "awsHost") (ne $v nil)}}
+        aws_host = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "awsService") (ne $v nil)}}
+        aws_service = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "propertyIdTag") (ne $v nil)}}
+		property_id_tag = {{$v}}
+{{- end}}
+{{- if and (eq $k "hostnameTag") (ne $v nil)}}
+		hostname_tag = {{$v}}
+{{- end}}
+{{- if and (eq $k "roleArn") (ne $v nil)}}
+        role_arn = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "awsArRegion") (ne $v nil)}}
+        aws_ar_region = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "endPointService") (ne $v nil)}}
+        end_point_service = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "originLocationTitle") (ne $v nil)}}
+        origin_location_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "country") (ne $v nil)}}
+        country = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "adcTitle") (ne $v nil)}}
+        adc_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "directConnectGeo") (ne $v nil)}}
+        direct_connect_geo = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "originCharacteristicsWsd"}}
+origin_characteristics_wsd {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "origintype") (ne $v nil)}}
+        origintype = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "originFailureRecoveryMethod"}}
+origin_failure_recovery_method {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "recoveryMethod") (ne $v nil)}}
+        recovery_method = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "customStatusCode") (ne $v nil)}}
+        custom_status_code = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "originFailureRecoveryPolicy"}}
+origin_failure_recovery_policy {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "tuningParameters") (ne $v nil)}}
+        tuning_parameters = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "enableIPAvoidance") (ne $v nil)}}
+		enable_ip_avoidance = {{$v}}
+{{- end}}
+{{- if and (eq $k "ipAvoidanceErrorThreshold") (ne $v nil)}}
+		ip_avoidance_error_threshold = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "ipAvoidanceRetryInterval") (ne $v nil)}}
+		ip_avoidance_retry_interval = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "binaryEquivalentContent") (ne $v nil)}}
+		binary_equivalent_content = {{$v}}
+{{- end}}
+{{- if and (eq $k "originResponsivenessMonitoring") (ne $v nil)}}
+        origin_responsiveness_monitoring = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "monitorOriginResponsiveness") (ne $v nil)}}
+		monitor_origin_responsiveness = {{$v}}
+{{- end}}
+{{- if and (eq $k "originResponsivenessTimeout") (ne $v nil)}}
+        origin_responsiveness_timeout = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "originResponsivenessCustomTimeout") (ne $v nil)}}
+		origin_responsiveness_custom_timeout = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "originResponsivenessEnableRetry") (ne $v nil)}}
+		origin_responsiveness_enable_retry = {{$v}}
+{{- end}}
+{{- if and (eq $k "originResponsivenessEnableRecovery") (ne $v nil)}}
+		origin_responsiveness_enable_recovery = {{$v}}
+{{- end}}
+{{- if and (eq $k "originResponsivenessRecoveryConfigName") (ne $v nil)}}
+        origin_responsiveness_recovery_config_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "statusCodeMonitoring1") (ne $v nil)}}
+        status_code_monitoring1 = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "monitorStatusCodes1") (ne $v nil)}}
+		monitor_status_codes1 = {{$v}}
+{{- end}}
+{{- if eq $k "monitorResponseCodes1"}}
+		monitor_response_codes1 = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "monitorStatusCodes1EnableRetry") (ne $v nil)}}
+		monitor_status_codes1_enable_retry = {{$v}}
+{{- end}}
+{{- if and (eq $k "monitorStatusCodes1EnableRecovery") (ne $v nil)}}
+		monitor_status_codes1_enable_recovery = {{$v}}
+{{- end}}
+{{- if and (eq $k "monitorStatusCodes1RecoveryConfigName") (ne $v nil)}}
+        monitor_status_codes1_recovery_config_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "statusCodeMonitoring2") (ne $v nil)}}
+        status_code_monitoring2 = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "monitorStatusCodes2") (ne $v nil)}}
+		monitor_status_codes2 = {{$v}}
+{{- end}}
+{{- if eq $k "monitorResponseCodes2"}}
+		monitor_response_codes2 = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "monitorStatusCodes2EnableRetry") (ne $v nil)}}
+		monitor_status_codes2_enable_retry = {{$v}}
+{{- end}}
+{{- if and (eq $k "monitorStatusCodes2EnableRecovery") (ne $v nil)}}
+		monitor_status_codes2_enable_recovery = {{$v}}
+{{- end}}
+{{- if and (eq $k "monitorStatusCodes2RecoveryConfigName") (ne $v nil)}}
+        monitor_status_codes2_recovery_config_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "statusCodeMonitoring3") (ne $v nil)}}
+        status_code_monitoring3 = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "monitorStatusCodes3") (ne $v nil)}}
+		monitor_status_codes3 = {{$v}}
+{{- end}}
+{{- if eq $k "monitorResponseCodes3"}}
+		monitor_response_codes3 = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "monitorStatusCodes3EnableRetry") (ne $v nil)}}
+		monitor_status_codes3_enable_retry = {{$v}}
+{{- end}}
+{{- if and (eq $k "monitorStatusCodes3EnableRecovery") (ne $v nil)}}
+		monitor_status_codes3_enable_recovery = {{$v}}
+{{- end}}
+{{- if and (eq $k "monitorStatusCodes3RecoveryConfigName") (ne $v nil)}}
+        monitor_status_codes3_recovery_config_name = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "originIpAcl"}}
+origin_ip_acl {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enable") (ne $v nil)}}
+		enable = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "permissionsPolicy"}}
+permissions_policy {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if eq $k "permissionsPolicyDirective"}}
+		permissions_policy_directive = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "allowList") (ne $v nil)}}
+        allow_list = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "persistentClientConnection"}}
+persistent_client_connection {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "timeout") (ne $v nil)}}
+        timeout = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "persistentConnection"}}
+persistent_connection {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "timeout") (ne $v nil)}}
+        timeout = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "personallyIdentifiableInformation"}}
+personally_identifiable_information {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "phasedRelease"}}
+phased_release {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "isSharedPolicy") (ne $v nil)}}
+		is_shared_policy = {{$v}}
+{{- end}}
+{{- if eq $k "cloudletPolicy" }}
+		{{- if $v}}
+		cloudlet_policy {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "id") (ne $v nil)}}
+		id = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "name") (ne $v nil)}}
+        name = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "cloudletSharedPolicy") (ne $v nil)}}
+		cloudlet_shared_policy = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "label") (ne $v nil)}}
+        label = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "populationTitle") (ne $v nil)}}
+        population_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "populationCookieType") (ne $v nil)}}
+        population_cookie_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "populationExpirationDate") (ne $v nil)}}
+        population_expiration_date = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "populationDuration") (ne $v nil)}}
+        population_duration = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "populationRefresh") (ne $v nil)}}
+		population_refresh = {{$v}}
+{{- end}}
+{{- if and (eq $k "failoverTitle") (ne $v nil)}}
+        failover_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "failoverEnabled") (ne $v nil)}}
+		failover_enabled = {{$v}}
+{{- end}}
+{{- if eq $k "failoverResponseCode"}}
+		failover_response_code = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "failoverDuration") (ne $v nil)}}
+		failover_duration = {{$v | AsInt}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "preconnect"}}
+preconnect {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if eq $k "preconnectlist"}}
+		preconnectlist = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "predictiveContentDelivery"}}
+predictive_content_delivery {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "predictivePrefetching"}}
+predictive_prefetching {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "accuracyTarget") (ne $v nil)}}
+        accuracy_target = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "prefetch"}}
+prefetch {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "prefetchable"}}
+prefetchable {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "prefreshCache"}}
+prefresh_cache {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "prefreshval") (ne $v nil)}}
+		prefreshval = {{$v | AsInt}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "quality"}}
+quality {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "origin_settings") (ne $v nil)}}
+        origin_settings = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "country") (ne $v nil)}}
+        country = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "audienceSettings") (ne $v nil)}}
+        audience_settings = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "endUserLocation") (ne $v nil)}}
+        end_user_location = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "maximumConcurrentUsers") (ne $v nil)}}
+        maximum_concurrent_users = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "contentSettings") (ne $v nil)}}
+        content_settings = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "contentType") (ne $v nil)}}
+        content_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "objectSize") (ne $v nil)}}
+        object_size = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "downloadType") (ne $v nil)}}
+        download_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "popularityDistribution") (ne $v nil)}}
+        popularity_distribution = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "deliveryType") (ne $v nil)}}
+        delivery_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "deliveryFormat") (ne $v nil)}}
+        delivery_format = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "segmentDuration") (ne $v nil)}}
+		segment_duration = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "catalogSize") (ne $v nil)}}
+        catalog_size = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "refreshRate") (ne $v nil)}}
+        refresh_rate = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "optimizeFor") (ne $v nil)}}
+        optimize_for = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "quicBeta"}}
+quic_beta {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "quicOfferPercentage") (ne $v nil)}}
+		quic_offer_percentage = {{$v | AsInt}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "randomSeek"}}
+random_seek {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "flv") (ne $v nil)}}
+		flv = {{$v}}
+{{- end}}
+{{- if and (eq $k "mp4") (ne $v nil)}}
+		mp4 = {{$v}}
+{{- end}}
+{{- if and (eq $k "maximumSize") (ne $v nil)}}
+        maximum_size = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "rapid"}}
+rapid {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "readTimeout"}}
+read_timeout {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "value") (ne $v nil)}}
+        value = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "realTimeReporting"}}
+real_time_reporting {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "advanced") (ne $v nil)}}
+		advanced = {{$v}}
+{{- end}}
+{{- if and (eq $k "beaconSamplingPercentage") (ne $v nil)}}
+		beacon_sampling_percentage = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "realUserMonitoring"}}
+real_user_monitoring {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "redirect"}}
+redirect {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "mobileDefaultChoice") (ne $v nil)}}
+        mobile_default_choice = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "destinationProtocol") (ne $v nil)}}
+        destination_protocol = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "destinationHostname") (ne $v nil)}}
+        destination_hostname = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "destinationHostnameSubdomain") (ne $v nil)}}
+        destination_hostname_subdomain = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "destinationHostnameSibling") (ne $v nil)}}
+        destination_hostname_sibling = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "destinationHostnameOther") (ne $v nil)}}
+        destination_hostname_other = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "destinationPath") (ne $v nil)}}
+        destination_path = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "destinationPathPrefix") (ne $v nil)}}
+        destination_path_prefix = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "destinationPathSuffixStatus") (ne $v nil)}}
+        destination_path_suffix_status = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "destinationPathSuffix") (ne $v nil)}}
+        destination_path_suffix = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "destinationPathOther") (ne $v nil)}}
+        destination_path_other = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "queryString") (ne $v nil)}}
+        query_string = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "responseCode") (ne $v nil)}}
+		response_code = {{$v | AsInt}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "redirectplus"}}
+redirectplus {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "destination") (ne $v nil)}}
+        destination = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "responseCode") (ne $v nil)}}
+		response_code = {{$v | AsInt}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "refererChecking"}}
+referer_checking {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "strict") (ne $v nil)}}
+		strict = {{$v}}
+{{- end}}
+{{- if eq $k "domains"}}
+		domains = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "allowChildren") (ne $v nil)}}
+		allow_children = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "removeQueryParameter"}}
+remove_query_parameter {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if eq $k "parameters"}}
+		parameters = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "removeVary"}}
+remove_vary {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "report"}}
+report {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "logHost") (ne $v nil)}}
+		log_host = {{$v}}
+{{- end}}
+{{- if and (eq $k "logReferer") (ne $v nil)}}
+		log_referer = {{$v}}
+{{- end}}
+{{- if and (eq $k "logUserAgent") (ne $v nil)}}
+		log_user_agent = {{$v}}
+{{- end}}
+{{- if and (eq $k "logAcceptLanguage") (ne $v nil)}}
+		log_accept_language = {{$v}}
+{{- end}}
+{{- if and (eq $k "logCookies") (ne $v nil)}}
+        log_cookies = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "cookies"}}
+		cookies = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "logCustomLogField") (ne $v nil)}}
+		log_custom_log_field = {{$v}}
+{{- end}}
+{{- if and (eq $k "customLogField") (ne $v nil)}}
+        custom_log_field = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "logEdgeIP") (ne $v nil)}}
+		log_edge_ip = {{$v}}
+{{- end}}
+{{- if and (eq $k "logXForwardedFor") (ne $v nil)}}
+		log_x_forwarded_for = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "requestClientHints"}}
+request_client_hints {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if eq $k "acceptCh"}}
+		accept_ch = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "acceptCriticalCh"}}
+		accept_critical_ch = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "reset") (ne $v nil)}}
+		reset = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "requestControl"}}
+request_control {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "isSharedPolicy") (ne $v nil)}}
+		is_shared_policy = {{$v}}
+{{- end}}
+{{- if eq $k "cloudletPolicy" }}
+		{{- if $v}}
+		cloudlet_policy {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "id") (ne $v nil)}}
+		id = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "name") (ne $v nil)}}
+        name = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "cloudletSharedPolicy") (ne $v nil)}}
+		cloudlet_shared_policy = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "enableBranded403") (ne $v nil)}}
+		enable_branded403 = {{$v}}
+{{- end}}
+{{- if and (eq $k "branded403StatusCode") (ne $v nil)}}
+		branded403_status_code = {{$v | AsInt}}
+{{- end}}
+{{- if eq $k "netStorage" }}
+		{{- if $v}}
+		net_storage {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "cpCode") (ne $v nil)}}
+		cp_code = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "downloadDomainName") (ne $v nil)}}
+        download_domain_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "g2oToken") (ne $v nil)}}
+        g2o_token = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "branded403File") (ne $v nil)}}
+        branded403_file = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "branded403Url") (ne $v nil)}}
+        branded403_url = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "brandedDenyCacheTtl") (ne $v nil)}}
+		branded_deny_cache_ttl = {{$v | AsInt}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "requestTypeMarker"}}
+request_type_marker {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "requestType") (ne $v nil)}}
+        request_type = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "resourceOptimizer"}}
+resource_optimizer {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "resourceOptimizerExtendedCompatibility"}}
+resource_optimizer_extended_compatibility {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "enableAllFeatures") (ne $v nil)}}
+		enable_all_features = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "responseCode"}}
+response_code {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "statusCode") (ne $v nil)}}
+		status_code = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "override206") (ne $v nil)}}
+		override206 = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "responseCookie"}}
+response_cookie {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "cookieName") (ne $v nil)}}
+        cookie_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "type") (ne $v nil)}}
+        type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "value") (ne $v nil)}}
+        value = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "format") (ne $v nil)}}
+        format = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "defaultDomain") (ne $v nil)}}
+		default_domain = {{$v}}
+{{- end}}
+{{- if and (eq $k "defaultPath") (ne $v nil)}}
+		default_path = {{$v}}
+{{- end}}
+{{- if and (eq $k "domain") (ne $v nil)}}
+        domain = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "path") (ne $v nil)}}
+        path = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "expires") (ne $v nil)}}
+        expires = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "expirationDate") (ne $v nil)}}
+        expiration_date = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "duration") (ne $v nil)}}
+        duration = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "sameSite") (ne $v nil)}}
+        same_site = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "secure") (ne $v nil)}}
+		secure = {{$v}}
+{{- end}}
+{{- if and (eq $k "httpOnly") (ne $v nil)}}
+		http_only = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "restrictObjectCaching"}}
+restrict_object_caching {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "maximumSize") (ne $v nil)}}
+        maximum_size = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "returnCacheStatus"}}
+return_cache_status {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "responseHeaderName") (ne $v nil)}}
+        response_header_name = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "rewriteUrl"}}
+rewrite_url {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "behavior") (ne $v nil)}}
+        behavior = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "match") (ne $v nil)}}
+        match = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "matchRegex") (ne $v nil)}}
+        match_regex = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "targetRegex") (ne $v nil)}}
+        target_regex = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "targetPath") (ne $v nil)}}
+        target_path = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "targetPathPrepend") (ne $v nil)}}
+        target_path_prepend = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "targetUrl") (ne $v nil)}}
+        target_url = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "matchMultiple") (ne $v nil)}}
+		match_multiple = {{$v}}
+{{- end}}
+{{- if and (eq $k "keepQueryString") (ne $v nil)}}
+		keep_query_string = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "rumCustom"}}
+rum_custom {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "rumSampleRate") (ne $v nil)}}
+		rum_sample_rate = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "rumGroupName") (ne $v nil)}}
+        rum_group_name = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "saasDefinitions"}}
+saas_definitions {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "customerTitle") (ne $v nil)}}
+        customer_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "customerAction") (ne $v nil)}}
+        customer_action = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "customerCnameEnabled") (ne $v nil)}}
+		customer_cname_enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "customerCnameLevel") (ne $v nil)}}
+		customer_cname_level = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "customerCookie") (ne $v nil)}}
+        customer_cookie = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "customerQueryString") (ne $v nil)}}
+        customer_query_string = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "customerRegex") (ne $v nil)}}
+        customer_regex = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "customerReplace") (ne $v nil)}}
+        customer_replace = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "applicationTitle") (ne $v nil)}}
+        application_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "applicationAction") (ne $v nil)}}
+        application_action = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "applicationCnameEnabled") (ne $v nil)}}
+		application_cname_enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "applicationCnameLevel") (ne $v nil)}}
+		application_cname_level = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "applicationCookie") (ne $v nil)}}
+        application_cookie = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "applicationQueryString") (ne $v nil)}}
+        application_query_string = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "applicationRegex") (ne $v nil)}}
+        application_regex = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "applicationReplace") (ne $v nil)}}
+        application_replace = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "usersTitle") (ne $v nil)}}
+        users_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "usersAction") (ne $v nil)}}
+        users_action = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "usersCnameEnabled") (ne $v nil)}}
+		users_cname_enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "usersCnameLevel") (ne $v nil)}}
+		users_cname_level = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "usersCookie") (ne $v nil)}}
+        users_cookie = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "usersQueryString") (ne $v nil)}}
+        users_query_string = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "usersRegex") (ne $v nil)}}
+        users_regex = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "usersReplace") (ne $v nil)}}
+        users_replace = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "salesForceCommerceCloudClient"}}
+sales_force_commerce_cloud_client {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "connectorId") (ne $v nil)}}
+        connector_id = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "originType") (ne $v nil)}}
+        origin_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "sf3cOriginHost") (ne $v nil)}}
+        sf3c_origin_host = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "originHostHeader") (ne $v nil)}}
+        origin_host_header = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "sf3cOriginHostHeader") (ne $v nil)}}
+        sf3c_origin_host_header = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "allowOverrideOriginCacheKey") (ne $v nil)}}
+		allow_override_origin_cache_key = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "salesForceCommerceCloudProvider"}}
+sales_force_commerce_cloud_provider {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "salesForceCommerceCloudProviderHostHeader"}}
+sales_force_commerce_cloud_provider_host_header {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "hostHeaderSource") (ne $v nil)}}
+        host_header_source = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "savePostDcaProcessing"}}
+save_post_dca_processing {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "scheduleInvalidation"}}
+schedule_invalidation {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "start") (ne $v nil)}}
+        start = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "repeat") (ne $v nil)}}
+		repeat = {{$v}}
+{{- end}}
+{{- if and (eq $k "repeatInterval") (ne $v nil)}}
+        repeat_interval = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "refreshMethod") (ne $v nil)}}
+        refresh_method = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "scriptManagement"}}
+script_management {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "serviceworker") (ne $v nil)}}
+        serviceworker = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "timestamp") (ne $v nil)}}
+		timestamp = {{$v | AsInt}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "segmentedContentProtection"}}
+segmented_content_protection {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "tokenAuthenticationTitle") (ne $v nil)}}
+        token_authentication_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "key") (ne $v nil)}}
+        key = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "useAdvanced") (ne $v nil)}}
+		use_advanced = {{$v}}
+{{- end}}
+{{- if and (eq $k "transitionKey") (ne $v nil)}}
+        transition_key = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "salt") (ne $v nil)}}
+        salt = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "headerForSalt"}}
+		header_for_salt = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "fieldCarryOver") (ne $v nil)}}
+        field_carry_over = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "sessionId") (ne $v nil)}}
+		session_id = {{$v}}
+{{- end}}
+{{- if and (eq $k "dataPayload") (ne $v nil)}}
+		data_payload = {{$v}}
+{{- end}}
+{{- if and (eq $k "ip") (ne $v nil)}}
+		ip = {{$v}}
+{{- end}}
+{{- if and (eq $k "acl") (ne $v nil)}}
+		acl = {{$v}}
+{{- end}}
+{{- if and (eq $k "tokenAuthHLSTitle") (ne $v nil)}}
+        token_auth_hls_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "enableTokenInURI") (ne $v nil)}}
+		enable_token_in_uri = {{$v}}
+{{- end}}
+{{- if eq $k "hlsMasterManifestFiles"}}
+		hls_master_manifest_files = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "tokenRevocationTitle") (ne $v nil)}}
+        token_revocation_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "tokenRevocationEnabled") (ne $v nil)}}
+		token_revocation_enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "revokedListId") (ne $v nil)}}
+		revoked_list_id = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "mediaEncryptionTitle") (ne $v nil)}}
+        media_encryption_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "hlsMediaEncryption") (ne $v nil)}}
+		hls_media_encryption = {{$v}}
+{{- end}}
+{{- if and (eq $k "dashMediaEncryption") (ne $v nil)}}
+		dash_media_encryption = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "segmentedMediaOptimization"}}
+segmented_media_optimization {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "behavior") (ne $v nil)}}
+        behavior = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "enableUllStreaming") (ne $v nil)}}
+		enable_ull_streaming = {{$v}}
+{{- end}}
+{{- if and (eq $k "showAdvanced") (ne $v nil)}}
+		show_advanced = {{$v}}
+{{- end}}
+{{- if and (eq $k "liveType") (ne $v nil)}}
+        live_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "startTime") (ne $v nil)}}
+        start_time = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "endTime") (ne $v nil)}}
+        end_time = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "dvrType") (ne $v nil)}}
+        dvr_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "dvrWindow") (ne $v nil)}}
+        dvr_window = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "segmentedMediaStreamingPrefetch"}}
+segmented_media_streaming_prefetch {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "setVariable"}}
+set_variable {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "variableName") (ne $v nil)}}
+        variable_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "valueSource") (ne $v nil)}}
+        value_source = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "variableValue") (ne $v nil)}}
+        variable_value = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "extractLocation") (ne $v nil)}}
+        extract_location = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "certificateFieldName") (ne $v nil)}}
+        certificate_field_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "headerName") (ne $v nil)}}
+        header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "responseHeaderName") (ne $v nil)}}
+        response_header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "setCookieName") (ne $v nil)}}
+        set_cookie_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "cookieName") (ne $v nil)}}
+        cookie_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "locationId") (ne $v nil)}}
+        location_id = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "pathComponentOffset") (ne $v nil)}}
+        path_component_offset = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "queryParameterName") (ne $v nil)}}
+        query_parameter_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "generator") (ne $v nil)}}
+        generator = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "numberOfBytes") (ne $v nil)}}
+		number_of_bytes = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "minRandomNumber") (ne $v nil)}}
+		min_random_number = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "maxRandomNumber") (ne $v nil)}}
+		max_random_number = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "transform") (ne $v nil)}}
+        transform = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "operandOne") (ne $v nil)}}
+        operand_one = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "algorithm") (ne $v nil)}}
+        algorithm = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "encryptionKey") (ne $v nil)}}
+        encryption_key = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "initializationVector") (ne $v nil)}}
+        initialization_vector = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "encryptionMode") (ne $v nil)}}
+        encryption_mode = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "nonce") (ne $v nil)}}
+        nonce = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "prependBytes") (ne $v nil)}}
+		prepend_bytes = {{$v}}
+{{- end}}
+{{- if and (eq $k "formatString") (ne $v nil)}}
+        format_string = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "paramName") (ne $v nil)}}
+        param_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "separator") (ne $v nil)}}
+        separator = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "min") (ne $v nil)}}
+		min = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "max") (ne $v nil)}}
+		max = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "hmacKey") (ne $v nil)}}
+        hmac_key = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "hmacAlgorithm") (ne $v nil)}}
+        hmac_algorithm = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "ipVersion") (ne $v nil)}}
+        ip_version = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "ipv6Prefix") (ne $v nil)}}
+		ipv6_prefix = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "ipv4Prefix") (ne $v nil)}}
+		ipv4_prefix = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "subString") (ne $v nil)}}
+        sub_string = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "regex") (ne $v nil)}}
+        regex = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "replacement") (ne $v nil)}}
+        replacement = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "caseSensitive") (ne $v nil)}}
+		case_sensitive = {{$v}}
+{{- end}}
+{{- if and (eq $k "globalSubstitution") (ne $v nil)}}
+		global_substitution = {{$v}}
+{{- end}}
+{{- if and (eq $k "startIndex") (ne $v nil)}}
+		start_index = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "endIndex") (ne $v nil)}}
+		end_index = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "exceptChars") (ne $v nil)}}
+        except_chars = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "forceChars") (ne $v nil)}}
+        force_chars = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "deviceProfile") (ne $v nil)}}
+        device_profile = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "simulateErrorCode"}}
+simulate_error_code {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "errorType") (ne $v nil)}}
+        error_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "timeout") (ne $v nil)}}
+        timeout = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "siteShield"}}
+site_shield {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if eq $k "ssmap" }}
+		{{- if $v}}
+		ssmap {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "name") (ne $v nil)}}
+        name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "value") (ne $v nil)}}
+        value = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "srmap") (ne $v nil)}}
+        srmap = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "chinaCdnMap") (ne $v nil)}}
+        china_cdn_map = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "hasMixedHosts") (ne $v nil)}}
+		has_mixed_hosts = {{$v}}
+{{- end}}
+{{- if and (eq $k "src") (ne $v nil)}}
+        src = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "nossmap") (ne $v nil)}}
+        nossmap = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "standardTLSMigration"}}
+standard_tls_migration {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "migrationFrom") (ne $v nil)}}
+        migration_from = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "allowHTTPSUpgrade") (ne $v nil)}}
+		allow_https_upgrade = {{$v}}
+{{- end}}
+{{- if and (eq $k "allowHTTPSDowngrade") (ne $v nil)}}
+		allow_https_downgrade = {{$v}}
+{{- end}}
+{{- if and (eq $k "migrationStartTime") (ne $v nil)}}
+        migration_start_time = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "migrationDuration") (ne $v nil)}}
+		migration_duration = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "cacheSharingStartTime") (ne $v nil)}}
+        cache_sharing_start_time = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "cacheSharingDuration") (ne $v nil)}}
+		cache_sharing_duration = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "isCertificateSNIOnly") (ne $v nil)}}
+		is_certificate_sni_only = {{$v}}
+{{- end}}
+{{- if and (eq $k "isTieredDistributionUsed") (ne $v nil)}}
+		is_tiered_distribution_used = {{$v}}
+{{- end}}
+{{- if and (eq $k "tdLocation") (ne $v nil)}}
+        td_location = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "standardTLSMigrationOverride"}}
+standard_tls_migration_override {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "info") (ne $v nil)}}
+        info = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "strictHeaderParsing"}}
+strict_header_parsing {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "validMode") (ne $v nil)}}
+		valid_mode = {{$v}}
+{{- end}}
+{{- if and (eq $k "strictMode") (ne $v nil)}}
+		strict_mode = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "subCustomer"}}
+sub_customer {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "origin") (ne $v nil)}}
+		origin = {{$v}}
+{{- end}}
+{{- if and (eq $k "partnerDomainSuffix") (ne $v nil)}}
+        partner_domain_suffix = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "caching") (ne $v nil)}}
+		caching = {{$v}}
+{{- end}}
+{{- if and (eq $k "referrer") (ne $v nil)}}
+		referrer = {{$v}}
+{{- end}}
+{{- if and (eq $k "ip") (ne $v nil)}}
+		ip = {{$v}}
+{{- end}}
+{{- if and (eq $k "geoLocation") (ne $v nil)}}
+		geo_location = {{$v}}
+{{- end}}
+{{- if and (eq $k "refreshContent") (ne $v nil)}}
+		refresh_content = {{$v}}
+{{- end}}
+{{- if and (eq $k "modifyPath") (ne $v nil)}}
+		modify_path = {{$v}}
+{{- end}}
+{{- if and (eq $k "cacheKey") (ne $v nil)}}
+		cache_key = {{$v}}
+{{- end}}
+{{- if and (eq $k "tokenAuthorization") (ne $v nil)}}
+		token_authorization = {{$v}}
+{{- end}}
+{{- if and (eq $k "siteFailover") (ne $v nil)}}
+		site_failover = {{$v}}
+{{- end}}
+{{- if and (eq $k "contentCompressor") (ne $v nil)}}
+		content_compressor = {{$v}}
+{{- end}}
+{{- if and (eq $k "accessControl") (ne $v nil)}}
+		access_control = {{$v}}
+{{- end}}
+{{- if and (eq $k "dynamicWebContent") (ne $v nil)}}
+		dynamic_web_content = {{$v}}
+{{- end}}
+{{- if and (eq $k "onDemandVideoDelivery") (ne $v nil)}}
+		on_demand_video_delivery = {{$v}}
+{{- end}}
+{{- if and (eq $k "largeFileDelivery") (ne $v nil)}}
+		large_file_delivery = {{$v}}
+{{- end}}
+{{- if and (eq $k "liveVideoDelivery") (ne $v nil)}}
+		live_video_delivery = {{$v}}
+{{- end}}
+{{- if and (eq $k "webApplicationFirewall") (ne $v nil)}}
+		web_application_firewall = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "sureRoute"}}
+sure_route {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "type") (ne $v nil)}}
+        type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "customMap") (ne $v nil)}}
+        custom_map = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "testObjectUrl") (ne $v nil)}}
+        test_object_url = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "srDownloadLinkTitle") (ne $v nil)}}
+        sr_download_link_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "toHostStatus") (ne $v nil)}}
+        to_host_status = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "toHost") (ne $v nil)}}
+        to_host = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "raceStatTtl") (ne $v nil)}}
+        race_stat_ttl = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "forceSslForward") (ne $v nil)}}
+		force_ssl_forward = {{$v}}
+{{- end}}
+{{- if and (eq $k "allowFCMParentOverride") (ne $v nil)}}
+		allow_fcm_parent_override = {{$v}}
+{{- end}}
+{{- if and (eq $k "enableCustomKey") (ne $v nil)}}
+		enable_custom_key = {{$v}}
+{{- end}}
+{{- if and (eq $k "customStatKey") (ne $v nil)}}
+        custom_stat_key = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "tcpOptimization"}}
+tcp_optimization {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "display") (ne $v nil)}}
+        display = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "teaLeaf"}}
+tea_leaf {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "limitToDynamic") (ne $v nil)}}
+		limit_to_dynamic = {{$v}}
+{{- end}}
+{{- if and (eq $k "ibmCustomerId") (ne $v nil)}}
+		ibm_customer_id = {{$v | AsInt}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "tieredDistribution"}}
+tiered_distribution {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "tieredDistributionMap") (ne $v nil)}}
+        tiered_distribution_map = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "tieredDistributionAdvanced"}}
+tiered_distribution_advanced {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "method") (ne $v nil)}}
+        method = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "policy") (ne $v nil)}}
+        policy = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "tieredDistributionMap") (ne $v nil)}}
+        tiered_distribution_map = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "allowall") (ne $v nil)}}
+		allowall = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "tieredDistributionCustomization"}}
+tiered_distribution_customization {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "tier1Title") (ne $v nil)}}
+        tier1_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "customMapEnabled") (ne $v nil)}}
+		custom_map_enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "customMapName") (ne $v nil)}}
+        custom_map_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "serialStart") (ne $v nil)}}
+        serial_start = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "serialEnd") (ne $v nil)}}
+        serial_end = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "hashAlgorithm") (ne $v nil)}}
+        hash_algorithm = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "cloudwrapperMapMigrationTitle") (ne $v nil)}}
+        cloudwrapper_map_migration_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "mapMigrationEnabled") (ne $v nil)}}
+		map_migration_enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "migrationWithinCwMapsEnabled") (ne $v nil)}}
+		migration_within_cw_maps_enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "location") (ne $v nil)}}
+        location = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "migrationStartDate") (ne $v nil)}}
+        migration_start_date = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "migrationEndDate") (ne $v nil)}}
+        migration_end_date = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "timeout"}}
+timeout {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "value") (ne $v nil)}}
+        value = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "uidConfiguration"}}
+uid_configuration {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "legalText") (ne $v nil)}}
+        legal_text = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "extractLocation") (ne $v nil)}}
+        extract_location = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "headerName") (ne $v nil)}}
+        header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "queryParameterName") (ne $v nil)}}
+        query_parameter_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "variableName") (ne $v nil)}}
+        variable_name = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "validateEntityTag"}}
+validate_entity_tag {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "verifyJsonWebToken"}}
+verify_json_web_token {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "extractLocation") (ne $v nil)}}
+        extract_location = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "headerName") (ne $v nil)}}
+        header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "queryParameterName") (ne $v nil)}}
+        query_parameter_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "jwt") (ne $v nil)}}
+        jwt = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "enableRS256") (ne $v nil)}}
+		enable_rs256 = {{$v}}
+{{- end}}
+{{- if and (eq $k "enableES256") (ne $v nil)}}
+		enable_es256 = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "verifyJsonWebTokenForDcp"}}
+verify_json_web_token_for_dcp {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "extractLocation") (ne $v nil)}}
+        extract_location = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "primaryLocation") (ne $v nil)}}
+        primary_location = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "customHeader") (ne $v nil)}}
+		custom_header = {{$v}}
+{{- end}}
+{{- if and (eq $k "headerName") (ne $v nil)}}
+        header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "queryParameterName") (ne $v nil)}}
+        query_parameter_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "jwt") (ne $v nil)}}
+        jwt = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "extractClientId") (ne $v nil)}}
+		extract_client_id = {{$v}}
+{{- end}}
+{{- if and (eq $k "clientId") (ne $v nil)}}
+        client_id = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "extractAuthorizations") (ne $v nil)}}
+		extract_authorizations = {{$v}}
+{{- end}}
+{{- if and (eq $k "authorizations") (ne $v nil)}}
+        authorizations = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "extractUserName") (ne $v nil)}}
+		extract_user_name = {{$v}}
+{{- end}}
+{{- if and (eq $k "userName") (ne $v nil)}}
+        user_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "enableRS256") (ne $v nil)}}
+		enable_rs256 = {{$v}}
+{{- end}}
+{{- if and (eq $k "enableES256") (ne $v nil)}}
+		enable_es256 = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "verifyTokenAuthorization"}}
+verify_token_authorization {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "useAdvanced") (ne $v nil)}}
+		use_advanced = {{$v}}
+{{- end}}
+{{- if and (eq $k "location") (ne $v nil)}}
+        location = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "locationId") (ne $v nil)}}
+        location_id = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "algorithm") (ne $v nil)}}
+        algorithm = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "escapeHmacInputs") (ne $v nil)}}
+		escape_hmac_inputs = {{$v}}
+{{- end}}
+{{- if and (eq $k "ignoreQueryString") (ne $v nil)}}
+		ignore_query_string = {{$v}}
+{{- end}}
+{{- if and (eq $k "key") (ne $v nil)}}
+        key = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "transitionKey") (ne $v nil)}}
+        transition_key = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "salt") (ne $v nil)}}
+        salt = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "failureResponse") (ne $v nil)}}
+		failure_response = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "virtualWaitingRoom"}}
+virtual_waiting_room {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "cloudletSharedPolicy") (ne $v nil)}}
+		cloudlet_shared_policy = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "domainConfig") (ne $v nil)}}
+        domain_config = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "customCookieDomain") (ne $v nil)}}
+        custom_cookie_domain = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "waitingRoomTitle") (ne $v nil)}}
+        waiting_room_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "waitingRoomPath") (ne $v nil)}}
+        waiting_room_path = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "waitingRoomAssetsPaths"}}
+		waiting_room_assets_paths = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "accessTitle") (ne $v nil)}}
+        access_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "sessionDuration") (ne $v nil)}}
+		session_duration = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "sessionAutoProlong") (ne $v nil)}}
+		session_auto_prolong = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "virtualWaitingRoomWithEdgeWorkers"}}
+virtual_waiting_room_with_edge_workers {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- end}}
+}
+{{- end}}
+{{- define "visitorPrioritization"}}
+visitor_prioritization {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if eq $k "cloudletPolicy" }}
+		{{- if $v}}
+		cloudlet_policy {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "id") (ne $v nil)}}
+		id = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "name") (ne $v nil)}}
+        name = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "userIdentificationTitle") (ne $v nil)}}
+        user_identification_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "userIdentificationByCookie") (ne $v nil)}}
+		user_identification_by_cookie = {{$v}}
+{{- end}}
+{{- if and (eq $k "userIdentificationKeyCookie") (ne $v nil)}}
+        user_identification_key_cookie = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "userIdentificationByHeaders") (ne $v nil)}}
+		user_identification_by_headers = {{$v}}
+{{- end}}
+{{- if eq $k "userIdentificationKeyHeaders"}}
+		user_identification_key_headers = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "userIdentificationByIp") (ne $v nil)}}
+		user_identification_by_ip = {{$v}}
+{{- end}}
+{{- if and (eq $k "userIdentificationByParams") (ne $v nil)}}
+		user_identification_by_params = {{$v}}
+{{- end}}
+{{- if eq $k "userIdentificationKeyParams"}}
+		user_identification_key_params = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "allowedUserCookieManagementTitle") (ne $v nil)}}
+        allowed_user_cookie_management_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "allowedUserCookieEnabled") (ne $v nil)}}
+		allowed_user_cookie_enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "allowedUserCookieLabel") (ne $v nil)}}
+        allowed_user_cookie_label = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "allowedUserCookieDuration") (ne $v nil)}}
+		allowed_user_cookie_duration = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "allowedUserCookieRefresh") (ne $v nil)}}
+		allowed_user_cookie_refresh = {{$v}}
+{{- end}}
+{{- if and (eq $k "allowedUserCookieAdvanced") (ne $v nil)}}
+		allowed_user_cookie_advanced = {{$v}}
+{{- end}}
+{{- if and (eq $k "allowedUserCookieAutomaticSalt") (ne $v nil)}}
+		allowed_user_cookie_automatic_salt = {{$v}}
+{{- end}}
+{{- if and (eq $k "allowedUserCookieSalt") (ne $v nil)}}
+        allowed_user_cookie_salt = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "allowedUserCookieDomainType") (ne $v nil)}}
+        allowed_user_cookie_domain_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "allowedUserCookieDomain") (ne $v nil)}}
+        allowed_user_cookie_domain = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "allowedUserCookieHttpOnly") (ne $v nil)}}
+		allowed_user_cookie_http_only = {{$v}}
+{{- end}}
+{{- if and (eq $k "waitingRoomCookieManagementTitle") (ne $v nil)}}
+        waiting_room_cookie_management_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "waitingRoomCookieEnabled") (ne $v nil)}}
+		waiting_room_cookie_enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "waitingRoomCookieShareLabel") (ne $v nil)}}
+		waiting_room_cookie_share_label = {{$v}}
+{{- end}}
+{{- if and (eq $k "waitingRoomCookieLabel") (ne $v nil)}}
+        waiting_room_cookie_label = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "waitingRoomCookieDuration") (ne $v nil)}}
+		waiting_room_cookie_duration = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "waitingRoomCookieAdvanced") (ne $v nil)}}
+		waiting_room_cookie_advanced = {{$v}}
+{{- end}}
+{{- if and (eq $k "waitingRoomCookieAutomaticSalt") (ne $v nil)}}
+		waiting_room_cookie_automatic_salt = {{$v}}
+{{- end}}
+{{- if and (eq $k "waitingRoomCookieSalt") (ne $v nil)}}
+        waiting_room_cookie_salt = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "waitingRoomCookieDomainType") (ne $v nil)}}
+        waiting_room_cookie_domain_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "waitingRoomCookieDomain") (ne $v nil)}}
+        waiting_room_cookie_domain = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "waitingRoomCookieHttpOnly") (ne $v nil)}}
+		waiting_room_cookie_http_only = {{$v}}
+{{- end}}
+{{- if and (eq $k "waitingRoomManagementTitle") (ne $v nil)}}
+        waiting_room_management_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "waitingRoomStatusCode") (ne $v nil)}}
+		waiting_room_status_code = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "waitingRoomUseCpCode") (ne $v nil)}}
+		waiting_room_use_cp_code = {{$v}}
+{{- end}}
+{{- if eq $k "waitingRoomCpCode" }}
+		{{- if $v}}
+		waiting_room_cp_code {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "id") (ne $v nil)}}
+		id = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "name") (ne $v nil)}}
+        name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "createdDate") (ne $v nil)}}
+		created_date = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "description") (ne $v nil)}}
+        description = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "products"}}
+		products = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "cpCodeLimits" }}
+		{{- if $v}}
+		cp_code_limits {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "currentCapacity") (ne $v nil)}}
+		current_capacity = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "limit") (ne $v nil)}}
+		limit = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "limitType") (ne $v nil)}}
+        limit_type = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if eq $k "waitingRoomNetStorage" }}
+		{{- if $v}}
+		waiting_room_net_storage {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "cpCode") (ne $v nil)}}
+		cp_code = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "downloadDomainName") (ne $v nil)}}
+        download_domain_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "g2oToken") (ne $v nil)}}
+        g2o_token = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "waitingRoomDirectory") (ne $v nil)}}
+        waiting_room_directory = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "waitingRoomCacheTtl") (ne $v nil)}}
+		waiting_room_cache_ttl = {{$v | AsInt}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "visitorPrioritizationFifo"}}
+visitor_prioritization_fifo {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "cloudletSharedPolicy") (ne $v nil)}}
+		cloudlet_shared_policy = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "domainConfig") (ne $v nil)}}
+        domain_config = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "customCookieDomain") (ne $v nil)}}
+        custom_cookie_domain = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "waitingRoomTitle") (ne $v nil)}}
+        waiting_room_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "waitingRoomPath") (ne $v nil)}}
+        waiting_room_path = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "waitingRoomAssetsPaths"}}
+		waiting_room_assets_paths = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "accessTitle") (ne $v nil)}}
+        access_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "sessionDuration") (ne $v nil)}}
+		session_duration = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "sessionAutoProlong") (ne $v nil)}}
+		session_auto_prolong = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "visitorPrioritizationFifoStandalone"}}
+visitor_prioritization_fifo_standalone {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- end}}
+}
+{{- end}}
+{{- define "watermarking"}}
+watermarking {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enable") (ne $v nil)}}
+		enable = {{$v}}
+{{- end}}
+{{- if and (eq $k "tokenSigningTitle") (ne $v nil)}}
+        token_signing_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "signatureVerificationEnable") (ne $v nil)}}
+		signature_verification_enable = {{$v}}
+{{- end}}
+{{- if and (eq $k "verificationKeyId1") (ne $v nil)}}
+        verification_key_id1 = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "verificationPublicKey1") (ne $v nil)}}
+        verification_public_key1 = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "verificationKeyId2") (ne $v nil)}}
+        verification_key_id2 = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "verificationPublicKey2") (ne $v nil)}}
+        verification_public_key2 = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "patternEncryptionTitle") (ne $v nil)}}
+        pattern_encryption_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "patternDecryptionEnable") (ne $v nil)}}
+		pattern_decryption_enable = {{$v}}
+{{- end}}
+{{- if and (eq $k "decryptionPasswordId1") (ne $v nil)}}
+        decryption_password_id1 = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "decryptionPassword1") (ne $v nil)}}
+        decryption_password1 = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "decryptionPasswordId2") (ne $v nil)}}
+        decryption_password_id2 = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "decryptionPassword2") (ne $v nil)}}
+        decryption_password2 = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "miscellaneousSettingsTitle") (ne $v nil)}}
+        miscellaneous_settings_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "useOriginalAsA") (ne $v nil)}}
+		use_original_as_a = {{$v}}
+{{- end}}
+{{- if and (eq $k "abVariantLocation") (ne $v nil)}}
+        ab_variant_location = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "webApplicationFirewall"}}
+web_application_firewall {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if eq $k "firewallConfiguration" }}
+		{{- if $v}}
+		firewall_configuration {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "configId") (ne $v nil)}}
+		config_id = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "productionStatus") (ne $v nil)}}
+        production_status = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "stagingStatus") (ne $v nil)}}
+        staging_status = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "productionVersion") (ne $v nil)}}
+		production_version = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "stagingVersion") (ne $v nil)}}
+		staging_version = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "fileName") (ne $v nil)}}
+        file_name = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "webSockets"}}
+web_sockets {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "webdav"}}
+webdav {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+
+
+{{- define "advancedImMatch"}}
+{{- $v := .Options}}
+advanced_im_match {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "matchOn") (ne $v nil)}}
+        match_on = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "bucket"}}
+{{- $v := .Options}}
+bucket {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "percentage") (ne $v nil)}}
+		percentage = {{$v | AsInt}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "cacheability"}}
+{{- $v := .Options}}
+cacheability {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "value") (ne $v nil)}}
+        value = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "chinaCdnRegion"}}
+{{- $v := .Options}}
+china_cdn_region {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "clientCertificate"}}
+{{- $v := .Options}}
+client_certificate {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "isCertificatePresent") (ne $v nil)}}
+		is_certificate_present = {{$v}}
+{{- end}}
+{{- if and (eq $k "isCertificateValid") (ne $v nil)}}
+        is_certificate_valid = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "enforceMtls") (ne $v nil)}}
+		enforce_mtls = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "clientIp"}}
+{{- $v := .Options}}
+client_ip {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "values"}}
+		values = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "useHeaders") (ne $v nil)}}
+		use_headers = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "clientIpVersion"}}
+{{- $v := .Options}}
+client_ip_version {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "value") (ne $v nil)}}
+        value = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "useXForwardedFor") (ne $v nil)}}
+		use_x_forwarded_for = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "cloudletsOrigin"}}
+{{- $v := .Options}}
+cloudlets_origin {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "originId") (ne $v nil)}}
+        origin_id = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "contentDeliveryNetwork"}}
+{{- $v := .Options}}
+content_delivery_network {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "network") (ne $v nil)}}
+        network = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "contentType"}}
+{{- $v := .Options}}
+content_type {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "values"}}
+		values = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "matchWildcard") (ne $v nil)}}
+		match_wildcard = {{$v}}
+{{- end}}
+{{- if and (eq $k "matchCaseSensitive") (ne $v nil)}}
+		match_case_sensitive = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "deviceCharacteristic"}}
+{{- $v := .Options}}
+device_characteristic {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "characteristic") (ne $v nil)}}
+        characteristic = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "stringMatchOperator") (ne $v nil)}}
+        string_match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "numericMatchOperator") (ne $v nil)}}
+        numeric_match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "versionMatchOperator") (ne $v nil)}}
+        version_match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "booleanValue") (ne $v nil)}}
+		boolean_value = {{$v}}
+{{- end}}
+{{- if eq $k "stringValue"}}
+		string_value = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "numericValue") (ne $v nil)}}
+		numeric_value = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "versionValue") (ne $v nil)}}
+        version_value = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "matchCaseSensitive") (ne $v nil)}}
+		match_case_sensitive = {{$v}}
+{{- end}}
+{{- if and (eq $k "matchWildcard") (ne $v nil)}}
+		match_wildcard = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "ecmdAuthGroups"}}
+{{- $v := .Options}}
+ecmd_auth_groups {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "value") (ne $v nil)}}
+        value = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "ecmdAuthScheme"}}
+{{- $v := .Options}}
+ecmd_auth_scheme {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "authScheme") (ne $v nil)}}
+        auth_scheme = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "ecmdIsAuthenticated"}}
+{{- $v := .Options}}
+ecmd_is_authenticated {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "ecmdUsername"}}
+{{- $v := .Options}}
+ecmd_username {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "value") (ne $v nil)}}
+        value = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "length") (ne $v nil)}}
+        length = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "edgeWorkersFailure"}}
+{{- $v := .Options}}
+edge_workers_failure {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "execStatus") (ne $v nil)}}
+        exec_status = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "fileExtension"}}
+{{- $v := .Options}}
+file_extension {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "values"}}
+		values = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "matchCaseSensitive") (ne $v nil)}}
+		match_case_sensitive = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "filename"}}
+{{- $v := .Options}}
+filename {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "values"}}
+		values = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "matchCaseSensitive") (ne $v nil)}}
+		match_case_sensitive = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "hostname"}}
+{{- $v := .Options}}
+hostname {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "values"}}
+		values = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "matchAdvanced"}}
+{{- $v := .Options}}
+match_advanced {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "description") (ne $v nil)}}
+        description = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "openXml") (ne $v nil)}}
+        open_xml = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "closeXml") (ne $v nil)}}
+        close_xml = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "matchCpCode"}}
+{{- $v := .Options}}
+match_cp_code {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if eq $k "value" }}
+		{{- if $v}}
+		value {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "id") (ne $v nil)}}
+		id = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "name") (ne $v nil)}}
+        name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "createdDate") (ne $v nil)}}
+		created_date = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "description") (ne $v nil)}}
+        description = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "products"}}
+		products = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "cpCodeLimits" }}
+		{{- if $v}}
+		cp_code_limits {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "currentCapacity") (ne $v nil)}}
+		current_capacity = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "limit") (ne $v nil)}}
+		limit = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "limitType") (ne $v nil)}}
+        limit_type = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "matchResponseCode"}}
+{{- $v := .Options}}
+match_response_code {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "values"}}
+		values = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "lowerBound") (ne $v nil)}}
+		lower_bound = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "upperBound") (ne $v nil)}}
+		upper_bound = {{$v | AsInt}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "matchVariable"}}
+{{- $v := .Options}}
+match_variable {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "variableName") (ne $v nil)}}
+        variable_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "variableValues"}}
+		variable_values = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "variableExpression") (ne $v nil)}}
+        variable_expression = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "lowerBound") (ne $v nil)}}
+        lower_bound = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "upperBound") (ne $v nil)}}
+        upper_bound = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "matchWildcard") (ne $v nil)}}
+		match_wildcard = {{$v}}
+{{- end}}
+{{- if and (eq $k "matchCaseSensitive") (ne $v nil)}}
+		match_case_sensitive = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "metadataStage"}}
+{{- $v := .Options}}
+metadata_stage {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "value") (ne $v nil)}}
+        value = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "originTimeout"}}
+{{- $v := .Options}}
+origin_timeout {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "path"}}
+{{- $v := .Options}}
+path {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "values"}}
+		values = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "matchCaseSensitive") (ne $v nil)}}
+		match_case_sensitive = {{$v}}
+{{- end}}
+{{- if and (eq $k "normalize") (ne $v nil)}}
+		normalize = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "queryStringParameter"}}
+{{- $v := .Options}}
+query_string_parameter {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "parameterName") (ne $v nil)}}
+        parameter_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "values"}}
+		values = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "lowerBound") (ne $v nil)}}
+		lower_bound = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "upperBound") (ne $v nil)}}
+		upper_bound = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "matchWildcardName") (ne $v nil)}}
+		match_wildcard_name = {{$v}}
+{{- end}}
+{{- if and (eq $k "matchCaseSensitiveName") (ne $v nil)}}
+		match_case_sensitive_name = {{$v}}
+{{- end}}
+{{- if and (eq $k "matchWildcardValue") (ne $v nil)}}
+		match_wildcard_value = {{$v}}
+{{- end}}
+{{- if and (eq $k "matchCaseSensitiveValue") (ne $v nil)}}
+		match_case_sensitive_value = {{$v}}
+{{- end}}
+{{- if and (eq $k "escapeValue") (ne $v nil)}}
+		escape_value = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "random"}}
+{{- $v := .Options}}
+random {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "bucket") (ne $v nil)}}
+		bucket = {{$v | AsInt}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "recoveryConfig"}}
+{{- $v := .Options}}
+recovery_config {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "configName") (ne $v nil)}}
+        config_name = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "regularExpression"}}
+{{- $v := .Options}}
+regular_expression {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchString") (ne $v nil)}}
+        match_string = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "regex") (ne $v nil)}}
+        regex = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "caseSensitive") (ne $v nil)}}
+		case_sensitive = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "requestCookie"}}
+{{- $v := .Options}}
+request_cookie {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "cookieName") (ne $v nil)}}
+        cookie_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "value") (ne $v nil)}}
+        value = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "lowerBound") (ne $v nil)}}
+		lower_bound = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "upperBound") (ne $v nil)}}
+		upper_bound = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "matchWildcardName") (ne $v nil)}}
+		match_wildcard_name = {{$v}}
+{{- end}}
+{{- if and (eq $k "matchCaseSensitiveName") (ne $v nil)}}
+		match_case_sensitive_name = {{$v}}
+{{- end}}
+{{- if and (eq $k "matchWildcardValue") (ne $v nil)}}
+		match_wildcard_value = {{$v}}
+{{- end}}
+{{- if and (eq $k "matchCaseSensitiveValue") (ne $v nil)}}
+		match_case_sensitive_value = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "requestHeader"}}
+{{- $v := .Options}}
+request_header {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "headerName") (ne $v nil)}}
+        header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "values"}}
+		values = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "matchWildcardName") (ne $v nil)}}
+		match_wildcard_name = {{$v}}
+{{- end}}
+{{- if and (eq $k "matchWildcardValue") (ne $v nil)}}
+		match_wildcard_value = {{$v}}
+{{- end}}
+{{- if and (eq $k "matchCaseSensitiveValue") (ne $v nil)}}
+		match_case_sensitive_value = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "requestMethod"}}
+{{- $v := .Options}}
+request_method {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "value") (ne $v nil)}}
+        value = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "requestProtocol"}}
+{{- $v := .Options}}
+request_protocol {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "value") (ne $v nil)}}
+        value = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "requestType"}}
+{{- $v := .Options}}
+request_type {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "value") (ne $v nil)}}
+        value = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "responseHeader"}}
+{{- $v := .Options}}
+response_header {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "headerName") (ne $v nil)}}
+        header_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "values"}}
+		values = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "lowerBound") (ne $v nil)}}
+		lower_bound = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "upperBound") (ne $v nil)}}
+		upper_bound = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "matchWildcardName") (ne $v nil)}}
+		match_wildcard_name = {{$v}}
+{{- end}}
+{{- if and (eq $k "matchWildcardValue") (ne $v nil)}}
+		match_wildcard_value = {{$v}}
+{{- end}}
+{{- if and (eq $k "matchCaseSensitiveValue") (ne $v nil)}}
+		match_case_sensitive_value = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "serverLocation"}}
+{{- $v := .Options}}
+server_location {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "locationType") (ne $v nil)}}
+        location_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "countries"}}
+		countries = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "continents"}}
+		continents = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "regions"}}
+		regions = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "time"}}
+{{- $v := .Options}}
+time {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "repeatInterval") (ne $v nil)}}
+        repeat_interval = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "repeatDuration") (ne $v nil)}}
+        repeat_duration = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "lastingDuration") (ne $v nil)}}
+        lasting_duration = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "lastingDate") (ne $v nil)}}
+        lasting_date = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "repeatBeginDate") (ne $v nil)}}
+        repeat_begin_date = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "applyDaylightSavingsTime") (ne $v nil)}}
+		apply_daylight_savings_time = {{$v}}
+{{- end}}
+{{- if and (eq $k "beginDate") (ne $v nil)}}
+        begin_date = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "endDate") (ne $v nil)}}
+        end_date = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "tokenAuthorization"}}
+{{- $v := .Options}}
+token_authorization {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "statusList"}}
+		status_list = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "userAgent"}}
+{{- $v := .Options}}
+user_agent {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "values"}}
+		values = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "matchWildcard") (ne $v nil)}}
+		match_wildcard = {{$v}}
+{{- end}}
+{{- if and (eq $k "matchCaseSensitive") (ne $v nil)}}
+		match_case_sensitive = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "userLocation"}}
+{{- $v := .Options}}
+user_location {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "field") (ne $v nil)}}
+        field = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "countryValues"}}
+		country_values = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "continentValues"}}
+		continent_values = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "regionValues"}}
+		region_values = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "checkIps") (ne $v nil)}}
+        check_ips = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "useOnlyFirstXForwardedForIp") (ne $v nil)}}
+		use_only_first_x_forwarded_for_ip = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "userNetwork"}}
+{{- $v := .Options}}
+user_network {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "field") (ne $v nil)}}
+        field = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "networkTypeValues"}}
+		network_type_values = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "networkValues"}}
+		network_values = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "bandwidthValues"}}
+		bandwidth_values = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if and (eq $k "checkIps") (ne $v nil)}}
+        check_ips = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "useOnlyFirstXForwardedForIp") (ne $v nil)}}
+		use_only_first_x_forwarded_for_ip = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "variableError"}}
+{{- $v := .Options}}
+variable_error {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "result") (ne $v nil)}}
+		result = {{$v}}
+{{- end}}
+{{- if eq $k "variableNames"}}
+		variable_names = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "virtualWaitingRoomRequest"}}
+{{- $v := .Options}}
+virtual_waiting_room_request {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "matchOn") (ne $v nil)}}
+        match_on = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "visitorPrioritizationRequest"}}
+{{- $v := .Options}}
+visitor_prioritization_request {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "matchOperator") (ne $v nil)}}
+        match_operator = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "matchOn") (ne $v nil)}}
+        match_on = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "rules_builder"}}
+{{- range $i, $r := .Rules}}
+data "akamai_property_rules_builder" "{{$r.TerraformName}}" {
+	{{- $children := $r.Children}}
+	{{- with $r.Rule}}
+	rules_v2024_05_31 {
+        name = "{{.Name | Escape}}"
+		{{- if eq $i 0}}
+        is_secure = {{.Options.IsSecure}}
+		{{- end}}
+        {{- if .Comments}}
+        comments = {{template "Text" .Comments}}
+        {{- end}}
+		{{- if ne $i 0}}
+		{{- if .CriteriaMustSatisfy}}
+        criteria_must_satisfy = "{{.CriteriaMustSatisfy}}"
+        {{- end}}
+        {{- end}}
+        {{- if .UUID}}
+        uuid = "{{.UUID}}"
+        {{- end}}
+        {{- if .TemplateUuid}}
+        template_uuid = "{{.TemplateUuid}}"
+        {{- end}}
+        {{- if .TemplateLink}}
+        template_link = "{{.TemplateLink}}"
+        {{- end}}
+		{{- if ne $i 0}}
+        {{- if .CriteriaLocked}}
+        criteria_locked = "{{.CriteriaLocked}}"
+        {{- end}}
+		{{- end}}
+{{- if eq $i 0}}
+{{- range .Variables}}
+        variable {
+            name        = "{{.Name | Escape}}"
+            {{- if .Description}}
+            description = "{{.Description | Escape}}"
+            {{- end}}
+            {{- if .Value}}
+            value       = "{{.Value | Escape}}"
+            {{- end}}
+            hidden      = {{.Hidden}}
+            sensitive   = {{.Sensitive}}
+        }
+{{- end}}
+		{{- if .AdvancedOverride}}
+        advanced_override = {{template "Text" .AdvancedOverride}}
+        {{- end}}
+		{{- with .CustomOverride}}
+		custom_override {
+			name        = "{{.Name}}"
+			override_id = "{{.OverrideID}}"
+		}
+		{{- end}}
+{{- end}}
+{{- if ne $i 0}}
+{{- range .Criteria}}
+        criterion {
+{{- template "Criteria" .}}
+        }
+{{- end}}
+{{- end}}
+{{- range .Behaviors}}
+        behavior {
+{{- template "Behavior" .}}
+		}
+{{- end}}
+		{{- if $children}}
+        children = [
+          {{range $children}}data.akamai_property_rules_builder.{{.TerraformName}}.json,
+        {{end}}]
+		{{- end}}
+	}
+	{{- end}}
+}
+{{end -}}
+{{- end}}
+{{- template "rules_builder" .}}
+{{- CheckErrors -}}

--- a/pkg/providers/papi/testdata/basic-bootstrap/property.tf
+++ b/pkg/providers/papi/testdata/basic-bootstrap/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic-non-default-ttl/import.sh
+++ b/pkg/providers/papi/testdata/basic-non-default-ttl/import.sh
@@ -1,0 +1,4 @@
+terraform init
+terraform import akamai_edge_hostname.test-edgesuite-net ehn_2867480,test_contract,grp_12345
+terraform import akamai_property.test-edgesuite-net prp_12345,test_contract,grp_12345,LATEST
+terraform import akamai_property_activation.test-edgesuite-net-staging prp_12345:STAGING

--- a/pkg/providers/papi/testdata/basic-non-default-ttl/mock_rules.json
+++ b/pkg/providers/papi/testdata/basic-non-default-ttl/mock_rules.json
@@ -1,0 +1,227 @@
+{
+  "accountId": "test_account",
+  "contractId": "test_contract",
+  "groupId": "grp_12345",
+  "propertyId": "prp_12345",
+  "propertyVersion": 5,
+  "etag": "4607f363da8bc05b0c0f0f7524985d2fbc5d864d",
+  "comments": "some comment",
+  "ruleFormat": "latest",
+  "rules": {
+    "behaviors": [
+      {
+        "name": "origin",
+        "options": {
+          "cacheKeyHostname": "ORIGIN_HOSTNAME",
+          "compress": true,
+          "enableTrueClientIp": false,
+          "forwardHostHeader": "REQUEST_HOST_HEADER",
+          "hostname": "1.2.3.4",
+          "httpPort": 80,
+          "httpsPort": 443,
+          "originSni": false,
+          "originType": "CUSTOMER",
+          "useUniqueCacheKey": false,
+          "verificationMode": "PLATFORM_SETTINGS"
+        }
+      },
+      {
+        "name": "cpCode",
+        "options": {
+          "value": {
+            "createdDate": 1506429558000,
+            "description": "Test-NewHire",
+            "id": 626358,
+            "name": "Test-NewHire",
+            "products": [
+              "Site_Defender"
+            ]
+          }
+        }
+      },
+      {
+        "name": "caching",
+        "options": {
+          "behavior": "NO_STORE"
+        }
+      },
+      {
+        "name": "allowPost",
+        "options": {
+          "allowWithoutContentLength": false,
+          "enabled": true
+        }
+      },
+      {
+        "name": "report",
+        "options": {
+          "logAcceptLanguage": false,
+          "logCookies": "OFF",
+          "logCustomLogField": false,
+          "logHost": false,
+          "logReferer": false,
+          "logUserAgent": true
+        }
+      },
+      {
+        "name": "advanced",
+        "options": {
+          "description": "extract inputs",
+          "xml": "\u003cassign:extract-value\u003e\n   \u003cvariable-name\u003eENDUSER\u003c/variable-name\u003e\n   \u003clocation\u003eQuery_String\u003c/location\u003e\n   \u003clocation-id\u003eenduser\u003c/location-id\u003e\n   \u003cseparator\u003e=\u003c/separator\u003e\n\u003c/assign:extract-value\u003e\n\u003cassign:extract-value\u003e\n   \u003cvariable-name\u003eGHOST\u003c/variable-name\u003e\n   \u003clocation\u003eQuery_String\u003c/location\u003e\n   \u003clocation-id\u003eghost\u003c/location-id\u003e\n   \u003cseparator\u003e=\u003c/separator\u003e\n\u003c/assign:extract-value\u003e\n\n\u003cassign:variable\u003e\n   \u003cname\u003eDISTANCE\u003c/name\u003e\n   \u003ctransform\u003e\n      \u003cgeo-distance\u003e\n         \u003cip1\u003e%(ENDUSER)\u003c/ip1\u003e\n         \u003cip2\u003e%(GHOST)\u003c/ip2\u003e\n      \u003c/geo-distance\u003e\n   \u003c/transform\u003e\n\u003c/assign:variable\u003e\n\n\n\n\u003cedgeservices:construct-response\u003e\n   \u003cstatus\u003eon\u003c/status\u003e\n   \u003chttp-status\u003e200\u003c/http-status\u003e\n   \u003cbody\u003e%(DISTANCE)\u003c/body\u003e\n   \u003cforce-cache-eviction\u003eoff\u003c/force-cache-eviction\u003e\n\u003c/edgeservices:construct-response\u003e\n\n\u003cedgeservices:modify-outgoing-response.add-header\u003e\n      \u003cname\u003eDistance\u003c/name\u003e\n      \u003cvalue\u003e%(DISTANCE)\u003c/value\u003e\n   \u003c/edgeservices:modify-outgoing-response.add-header\u003e"
+        },
+        "uuid": "feeaeff9-fe7e-4e27-ba0c-7b1dcecdba8b"
+      }
+    ],
+    "children": [
+      {
+        "behaviors": [
+          {
+            "name": "gzipResponse",
+            "options": {
+              "behavior": "ALWAYS"
+            }
+          }
+        ],
+        "criteria": [
+          {
+            "name": "contentType",
+            "options": {
+              "matchCaseSensitive": false,
+              "matchOperator": "IS_ONE_OF",
+              "matchWildcard": true,
+              "values": [
+                "text/html*",
+                "text/css*",
+                "application/x-javascript*"
+              ]
+            }
+          }
+        ],
+        "name": "Content Compression",
+        "options": {},
+        "criteriaMustSatisfy": "all"
+      },
+      {
+        "behaviors": [
+          {
+            "name": "caching",
+            "options": {
+              "behavior": "MAX_AGE",
+              "mustRevalidate": false,
+              "ttl": "1d"
+            }
+          }
+        ],
+        "criteria": [
+          {
+            "name": "fileExtension",
+            "options": {
+              "matchCaseSensitive": false,
+              "matchOperator": "IS_ONE_OF",
+              "values": [
+                "aif",
+                "aiff",
+                "au",
+                "avi",
+                "bin",
+                "bmp",
+                "cab",
+                "carb",
+                "cct",
+                "cdf",
+                "class",
+                "css",
+                "doc",
+                "dcr",
+                "dtd",
+                "exe",
+                "flv",
+                "gcf",
+                "gff",
+                "gif",
+                "grv",
+                "hdml",
+                "hqx",
+                "ico",
+                "ini",
+                "jpeg",
+                "jpg",
+                "js",
+                "mov",
+                "mp3",
+                "nc",
+                "pct",
+                "pdf",
+                "png",
+                "ppc",
+                "pws",
+                "swa",
+                "swf",
+                "txt",
+                "vbs",
+                "w32",
+                "wav",
+                "wbmp",
+                "wml",
+                "wmlc",
+                "wmls",
+                "wmlsc",
+                "xsd",
+                "zip",
+                "webp",
+                "jxr",
+                "hdp",
+                "wdp",
+                "pict",
+                "tif",
+                "tiff",
+                "mid",
+                "midi",
+                "ttf",
+                "eot",
+                "woff",
+                "otf",
+                "svg",
+                "svgz",
+                "jar",
+                "woff2"
+              ]
+            }
+          }
+        ],
+        "name": "Static Content",
+        "options": {},
+        "criteriaMustSatisfy": "all"
+      },
+      {
+        "behaviors": [
+          {
+            "name": "downstreamCache",
+            "options": {
+              "behavior": "TUNNEL_ORIGIN"
+            }
+          }
+        ],
+        "criteria": [
+          {
+            "name": "cacheability",
+            "options": {
+              "matchOperator": "IS_NOT",
+              "value": "CACHEABLE"
+            }
+          }
+        ],
+        "name": "Dynamic Content",
+        "options": {},
+        "criteriaMustSatisfy": "all"
+      }
+    ],
+    "name": "default",
+    "options": {},
+    "customOverride": {
+      "overrideId": "cbo_12345",
+      "name": "mdc"
+    },
+    "uuid": "default"
+  }
+}

--- a/pkg/providers/papi/testdata/basic-non-default-ttl/property-snippets/Content_Compression.json
+++ b/pkg/providers/papi/testdata/basic-non-default-ttl/property-snippets/Content_Compression.json
@@ -1,0 +1,28 @@
+{
+  "behaviors": [
+    {
+      "name": "gzipResponse",
+      "options": {
+        "behavior": "ALWAYS"
+      }
+    }
+  ],
+  "criteria": [
+    {
+      "name": "contentType",
+      "options": {
+        "matchCaseSensitive": false,
+        "matchOperator": "IS_ONE_OF",
+        "matchWildcard": true,
+        "values": [
+          "text/html*",
+          "text/css*",
+          "application/x-javascript*"
+        ]
+      }
+    }
+  ],
+  "name": "Content Compression",
+  "options": {},
+  "criteriaMustSatisfy": "all"
+}

--- a/pkg/providers/papi/testdata/basic-non-default-ttl/property-snippets/Dynamic_Content.json
+++ b/pkg/providers/papi/testdata/basic-non-default-ttl/property-snippets/Dynamic_Content.json
@@ -1,0 +1,22 @@
+{
+  "behaviors": [
+    {
+      "name": "downstreamCache",
+      "options": {
+        "behavior": "TUNNEL_ORIGIN"
+      }
+    }
+  ],
+  "criteria": [
+    {
+      "name": "cacheability",
+      "options": {
+        "matchOperator": "IS_NOT",
+        "value": "CACHEABLE"
+      }
+    }
+  ],
+  "name": "Dynamic Content",
+  "options": {},
+  "criteriaMustSatisfy": "all"
+}

--- a/pkg/providers/papi/testdata/basic-non-default-ttl/property-snippets/Static_Content.json
+++ b/pkg/providers/papi/testdata/basic-non-default-ttl/property-snippets/Static_Content.json
@@ -1,0 +1,92 @@
+{
+  "behaviors": [
+    {
+      "name": "caching",
+      "options": {
+        "behavior": "MAX_AGE",
+        "mustRevalidate": false,
+        "ttl": "1d"
+      }
+    }
+  ],
+  "criteria": [
+    {
+      "name": "fileExtension",
+      "options": {
+        "matchCaseSensitive": false,
+        "matchOperator": "IS_ONE_OF",
+        "values": [
+          "aif",
+          "aiff",
+          "au",
+          "avi",
+          "bin",
+          "bmp",
+          "cab",
+          "carb",
+          "cct",
+          "cdf",
+          "class",
+          "css",
+          "doc",
+          "dcr",
+          "dtd",
+          "exe",
+          "flv",
+          "gcf",
+          "gff",
+          "gif",
+          "grv",
+          "hdml",
+          "hqx",
+          "ico",
+          "ini",
+          "jpeg",
+          "jpg",
+          "js",
+          "mov",
+          "mp3",
+          "nc",
+          "pct",
+          "pdf",
+          "png",
+          "ppc",
+          "pws",
+          "swa",
+          "swf",
+          "txt",
+          "vbs",
+          "w32",
+          "wav",
+          "wbmp",
+          "wml",
+          "wmlc",
+          "wmls",
+          "wmlsc",
+          "xsd",
+          "zip",
+          "webp",
+          "jxr",
+          "hdp",
+          "wdp",
+          "pict",
+          "tif",
+          "tiff",
+          "mid",
+          "midi",
+          "ttf",
+          "eot",
+          "woff",
+          "otf",
+          "svg",
+          "svgz",
+          "jar",
+          "woff2"
+        ]
+      }
+    }
+  ],
+  "name": "Static Content",
+  "options": {},
+  "criteriaMustSatisfy": "all"
+}

--- a/pkg/providers/papi/testdata/basic-non-default-ttl/property-snippets/main.json
+++ b/pkg/providers/papi/testdata/basic-non-default-ttl/property-snippets/main.json
@@ -1,0 +1,88 @@
+{
+  "accountId": "test_account",
+  "contractId": "test_contract",
+  "groupId": "grp_12345",
+  "propertyId": "prp_12345",
+  "propertyVersion": 5,
+  "etag": "4607f363da8bc05b0c0f0f7524985d2fbc5d864d",
+  "ruleFormat": "latest",
+  "comments": "some comment",
+  "rules": {
+    "name": "default",
+    "behaviors": [
+      {
+        "name": "origin",
+        "options": {
+          "cacheKeyHostname": "ORIGIN_HOSTNAME",
+          "compress": true,
+          "enableTrueClientIp": false,
+          "forwardHostHeader": "REQUEST_HOST_HEADER",
+          "hostname": "1.2.3.4",
+          "httpPort": 80,
+          "httpsPort": 443,
+          "originSni": false,
+          "originType": "CUSTOMER",
+          "useUniqueCacheKey": false,
+          "verificationMode": "PLATFORM_SETTINGS"
+        }
+      },
+      {
+        "name": "cpCode",
+        "options": {
+          "value": {
+            "createdDate": 1506429558000,
+            "description": "Test-NewHire",
+            "id": 626358,
+            "name": "Test-NewHire",
+            "products": [
+              "Site_Defender"
+            ]
+          }
+        }
+      },
+      {
+        "name": "caching",
+        "options": {
+          "behavior": "NO_STORE"
+        }
+      },
+      {
+        "name": "allowPost",
+        "options": {
+          "allowWithoutContentLength": false,
+          "enabled": true
+        }
+      },
+      {
+        "name": "report",
+        "options": {
+          "logAcceptLanguage": false,
+          "logCookies": "OFF",
+          "logCustomLogField": false,
+          "logHost": false,
+          "logReferer": false,
+          "logUserAgent": true
+        }
+      },
+      {
+        "name": "advanced",
+        "options": {
+          "description": "extract inputs",
+          "xml": "\u003cassign:extract-value\u003e\n   \u003cvariable-name\u003eENDUSER\u003c/variable-name\u003e\n   \u003clocation\u003eQuery_String\u003c/location\u003e\n   \u003clocation-id\u003eenduser\u003c/location-id\u003e\n   \u003cseparator\u003e=\u003c/separator\u003e\n\u003c/assign:extract-value\u003e\n\u003cassign:extract-value\u003e\n   \u003cvariable-name\u003eGHOST\u003c/variable-name\u003e\n   \u003clocation\u003eQuery_String\u003c/location\u003e\n   \u003clocation-id\u003eghost\u003c/location-id\u003e\n   \u003cseparator\u003e=\u003c/separator\u003e\n\u003c/assign:extract-value\u003e\n\n\u003cassign:variable\u003e\n   \u003cname\u003eDISTANCE\u003c/name\u003e\n   \u003ctransform\u003e\n      \u003cgeo-distance\u003e\n         \u003cip1\u003e%(ENDUSER)\u003c/ip1\u003e\n         \u003cip2\u003e%(GHOST)\u003c/ip2\u003e\n      \u003c/geo-distance\u003e\n   \u003c/transform\u003e\n\u003c/assign:variable\u003e\n\n\n\n\u003cedgeservices:construct-response\u003e\n   \u003cstatus\u003eon\u003c/status\u003e\n   \u003chttp-status\u003e200\u003c/http-status\u003e\n   \u003cbody\u003e%(DISTANCE)\u003c/body\u003e\n   \u003cforce-cache-eviction\u003eoff\u003c/force-cache-eviction\u003e\n\u003c/edgeservices:construct-response\u003e\n\n\u003cedgeservices:modify-outgoing-response.add-header\u003e\n      \u003cname\u003eDistance\u003c/name\u003e\n      \u003cvalue\u003e%(DISTANCE)\u003c/value\u003e\n   \u003c/edgeservices:modify-outgoing-response.add-header\u003e"
+        },
+        "uuid": "feeaeff9-fe7e-4e27-ba0c-7b1dcecdba8b"
+      }
+    ],
+    "children": [
+      "#include:Content_Compression.json",
+      "#include:Static_Content.json",
+      "#include:Dynamic_Content.json"
+    ],
+    "uuid": "default",
+    "options": {},
+    "customOverride": {
+      "name": "mdc",
+      "overrideId": "cbo_12345"
+    }
+  }
+}

--- a/pkg/providers/papi/testdata/basic-non-default-ttl/property.tf
+++ b/pkg/providers/papi/testdata/basic-non-default-ttl/property.tf
@@ -1,0 +1,58 @@
+terraform {
+  required_providers {
+    akamai = {
+      source  = "akamai/akamai"
+      version = ">= 6.2.0"
+    }
+  }
+  required_version = ">= 1.0"
+}
+
+provider "akamai" {
+  edgerc         = var.edgerc_path
+  config_section = var.config_section
+}
+
+data "akamai_property_rules_template" "rules" {
+  template_file = abspath("${path.module}/property-snippets/main.json")
+}
+
+resource "akamai_edge_hostname" "test-edgesuite-net" {
+  contract_id   = var.contract_id
+  group_id      = var.group_id
+  ip_behavior   = "IPV6_COMPLIANCE"
+  edge_hostname = "test.edgesuite.net"
+  ttl           = 600
+}
+
+resource "akamai_property" "test-edgesuite-net" {
+  name        = "test.edgesuite.net"
+  contract_id = var.contract_id
+  group_id    = var.group_id
+  product_id  = "prd_HTTP_Content_Del"
+  hostnames {
+    cname_from             = "test.edgesuite.net"
+    cname_to               = akamai_edge_hostname.test-edgesuite-net.edge_hostname
+    cert_provisioning_type = "CPS_MANAGED"
+  }
+  rule_format = "latest"
+  rules       = data.akamai_property_rules_template.rules.json
+}
+
+# NOTE: Be careful when removing this resource as you can disable traffic
+resource "akamai_property_activation" "test-edgesuite-net-staging" {
+  property_id                    = akamai_property.test-edgesuite-net.id
+  contact                        = ["jsmith@akamai.com"]
+  version                        = var.activate_latest_on_staging ? akamai_property.test-edgesuite-net.latest_version : akamai_property.test-edgesuite-net.staging_version
+  network                        = "STAGING"
+  auto_acknowledge_rule_warnings = false
+}
+
+# NOTE: Be careful when removing this resource as you can disable traffic
+#resource "akamai_property_activation" "test-edgesuite-net-production" {
+#  property_id                    = akamai_property.test-edgesuite-net.id
+#  contact                        = []
+#  version                        = var.activate_latest_on_production ? akamai_property.test-edgesuite-net.latest_version : akamai_property.test-edgesuite-net.production_version
+#  network                        = "PRODUCTION"
+#  auto_acknowledge_rule_warnings = false
+#}

--- a/pkg/providers/papi/testdata/basic-non-default-ttl/property.tf
+++ b/pkg/providers/papi/testdata/basic-non-default-ttl/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic-non-default-ttl/variables.tf
+++ b/pkg/providers/papi/testdata/basic-non-default-ttl/variables.tf
@@ -1,0 +1,29 @@
+variable "edgerc_path" {
+  type    = string
+  default = "~/.edgerc"
+}
+
+variable "config_section" {
+  type    = string
+  default = "test_section"
+}
+
+variable "contract_id" {
+  type    = string
+  default = "test_contract"
+}
+
+variable "group_id" {
+  type    = string
+  default = "grp_12345"
+}
+
+variable "activate_latest_on_staging" {
+  type    = bool
+  default = true
+}
+
+#variable "activate_latest_on_production" {
+#  type    = bool
+#  default = true
+#}

--- a/pkg/providers/papi/testdata/basic-rules-datasource-empty-options/property.tf
+++ b/pkg/providers/papi/testdata/basic-rules-datasource-empty-options/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic-rules-datasource-schema-v2023-01-05/property.tf
+++ b/pkg/providers/papi/testdata/basic-rules-datasource-schema-v2023-01-05/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic-rules-datasource-schema-v2023-05-30/property.tf
+++ b/pkg/providers/papi/testdata/basic-rules-datasource-schema-v2023-05-30/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic-rules-datasource-schema-v2023-09-20/property.tf
+++ b/pkg/providers/papi/testdata/basic-rules-datasource-schema-v2023-09-20/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic-rules-datasource-schema-v2023-10-30/property.tf
+++ b/pkg/providers/papi/testdata/basic-rules-datasource-schema-v2023-10-30/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic-rules-datasource-schema-v2024-01-09/property.tf
+++ b/pkg/providers/papi/testdata/basic-rules-datasource-schema-v2024-01-09/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic-rules-datasource-schema-v2024-02-12/property.tf
+++ b/pkg/providers/papi/testdata/basic-rules-datasource-schema-v2024-02-12/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic-rules-datasource-schema-v2024-05-31/import.sh
+++ b/pkg/providers/papi/testdata/basic-rules-datasource-schema-v2024-05-31/import.sh
@@ -1,0 +1,2 @@
+terraform init
+terraform import akamai_property.test-edgesuite-net prp_12345,test_contract,grp_12345,LATEST

--- a/pkg/providers/papi/testdata/basic-rules-datasource-schema-v2024-05-31/mock_rules.json
+++ b/pkg/providers/papi/testdata/basic-rules-datasource-schema-v2024-05-31/mock_rules.json
@@ -1,0 +1,35 @@
+{
+  "accountId": "test_account",
+  "contractId": "test_contract",
+  "groupId": "grp_12345",
+  "propertyId": "prp_12345",
+  "propertyVersion": 5,
+  "etag": "4607f363da8bc05b0c0f0f7524985d2fbc5d864d",
+  "ruleFormat": "v2024-05-31",
+  "rules": {
+    "behaviors": [
+      {
+        "name": "datastream",
+        "options": {
+          "beaconStreamTitle": "test",
+          "collectMidgressTraffic": false,
+          "datastreamIds": "77-85-6",
+          "enabled": true,
+          "logEnabled": false,
+          "logStreamName": [
+            "60"
+          ],
+          "logStreamTitle": "test",
+          "samplingPercentage": 100,
+          "streamType": "LOG"
+        }
+      }
+    ],
+    "children": [],
+    "name": "default",
+    "options": {},
+    "variables": [],
+    "uuid": "default",
+    "criteriaMustSatisfy": "all"
+  }
+}

--- a/pkg/providers/papi/testdata/basic-rules-datasource-schema-v2024-05-31/property.tf
+++ b/pkg/providers/papi/testdata/basic-rules-datasource-schema-v2024-05-31/property.tf
@@ -1,0 +1,41 @@
+terraform {
+  required_providers {
+    akamai = {
+      source  = "akamai/akamai"
+      version = ">= 6.2.0"
+    }
+  }
+  required_version = ">= 1.0"
+}
+
+provider "akamai" {
+  edgerc         = var.edgerc_path
+  config_section = var.config_section
+}
+
+resource "akamai_property" "test-edgesuite-net" {
+  name        = "test.edgesuite.net"
+  contract_id = var.contract_id
+  group_id    = var.group_id
+  product_id  = "prd_HTTP_Content_Del"
+  rule_format = data.akamai_property_rules_builder.test-edgesuite-net_rule_default.rule_format
+  rules       = data.akamai_property_rules_builder.test-edgesuite-net_rule_default.json
+}
+
+# NOTE: Be careful when removing this resource as you can disable traffic
+#resource "akamai_property_activation" "test-edgesuite-net-staging" {
+#  property_id                    = akamai_property.test-edgesuite-net.id
+#  contact                        = []
+#  version                        = var.activate_latest_on_staging ? akamai_property.test-edgesuite-net.latest_version : akamai_property.test-edgesuite-net.staging_version
+#  network                        = "STAGING"
+#  auto_acknowledge_rule_warnings = false
+#}
+
+# NOTE: Be careful when removing this resource as you can disable traffic
+#resource "akamai_property_activation" "test-edgesuite-net-production" {
+#  property_id                    = akamai_property.test-edgesuite-net.id
+#  contact                        = []
+#  version                        = var.activate_latest_on_production ? akamai_property.test-edgesuite-net.latest_version : akamai_property.test-edgesuite-net.production_version
+#  network                        = "PRODUCTION"
+#  auto_acknowledge_rule_warnings = false
+#}

--- a/pkg/providers/papi/testdata/basic-rules-datasource-schema-v2024-05-31/property.tf
+++ b/pkg/providers/papi/testdata/basic-rules-datasource-schema-v2024-05-31/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic-rules-datasource-schema-v2024-05-31/rules.tf
+++ b/pkg/providers/papi/testdata/basic-rules-datasource-schema-v2024-05-31/rules.tf
@@ -1,0 +1,21 @@
+
+data "akamai_property_rules_builder" "test-edgesuite-net_rule_default" {
+  rules_v2024_05_31 {
+    name      = "default"
+    is_secure = false
+    uuid      = "default"
+    behavior {
+      datastream {
+        beacon_stream_title      = "test"
+        collect_midgress_traffic = false
+        datastream_ids           = "77-85-6"
+        enabled                  = true
+        log_enabled              = false
+        log_stream_name          = ["60", ]
+        log_stream_title         = "test"
+        sampling_percentage      = 100
+        stream_type              = "LOG"
+      }
+    }
+  }
+}

--- a/pkg/providers/papi/testdata/basic-rules-datasource-schema-v2024-05-31/variables.tf
+++ b/pkg/providers/papi/testdata/basic-rules-datasource-schema-v2024-05-31/variables.tf
@@ -1,0 +1,29 @@
+variable "edgerc_path" {
+  type    = string
+  default = "~/.edgerc"
+}
+
+variable "config_section" {
+  type    = string
+  default = "test_section"
+}
+
+variable "contract_id" {
+  type    = string
+  default = "test_contract"
+}
+
+variable "group_id" {
+  type    = string
+  default = "grp_12345"
+}
+
+#variable "activate_latest_on_staging" {
+#  type    = bool
+#  default = true
+#}
+
+#variable "activate_latest_on_production" {
+#  type    = bool
+#  default = true
+#}

--- a/pkg/providers/papi/testdata/basic-rules-datasource-serial/property.tf
+++ b/pkg/providers/papi/testdata/basic-rules-datasource-serial/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic-rules-datasource/property.tf
+++ b/pkg/providers/papi/testdata/basic-rules-datasource/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic-v1/property.tf
+++ b/pkg/providers/papi/testdata/basic-v1/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic/property.tf
+++ b/pkg/providers/papi/testdata/basic/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic_not_latest/property.tf
+++ b/pkg/providers/papi/testdata/basic_not_latest/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic_property_with_empty_hostname_id/property.tf
+++ b/pkg/providers/papi/testdata/basic_property_with_empty_hostname_id/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic_property_with_include/property.tf
+++ b/pkg/providers/papi/testdata/basic_property_with_include/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic_property_with_multiple_includes/property.tf
+++ b/pkg/providers/papi/testdata/basic_property_with_multiple_includes/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic_property_with_multiple_includes_rules_as_hcl/property.tf
+++ b/pkg/providers/papi/testdata/basic_property_with_multiple_includes_rules_as_hcl/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic_with_activation_note/property.tf
+++ b/pkg/providers/papi/testdata/basic_with_activation_note/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic_with_both_activations/property.tf
+++ b/pkg/providers/papi/testdata/basic_with_both_activations/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic_with_cert_provisioning_type/property.tf
+++ b/pkg/providers/papi/testdata/basic_with_cert_provisioning_type/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic_with_multiline_activation_note/property.tf
+++ b/pkg/providers/papi/testdata/basic_with_multiline_activation_note/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic_with_production_activation/property.tf
+++ b/pkg/providers/papi/testdata/basic_with_production_activation/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic_with_use_cases/property.tf
+++ b/pkg/providers/papi/testdata/basic_with_use_cases/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic_without_activation/property.tf
+++ b/pkg/providers/papi/testdata/basic_without_activation/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/enhancement-tls/property.tf
+++ b/pkg/providers/papi/testdata/enhancement-tls/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 6.2.0"
+      version = ">= 6.3.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/tools/name.go
+++ b/pkg/tools/name.go
@@ -1,0 +1,28 @@
+package tools
+
+import (
+	"regexp"
+	"strings"
+)
+
+var matchFirstCap = regexp.MustCompile("([^ _])([A-Z][a-z]+)")
+var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
+var nameRegexp = regexp.MustCompile(`[^\p{L}\p{Nl}\p{Mn}\p{Mc}\p{Nd}\p{Pc}\d\-_ ]`)
+
+// ToSnakeCase returns name using snake case notation - SomeName -> some_name
+func ToSnakeCase(str string) string {
+	snake := strings.Replace(str, " ", "_", -1)
+	snake, _ = strings.CutSuffix(snake, "_")
+	snake = matchFirstCap.ReplaceAllString(snake, "${1}_${2}")
+	snake = matchAllCap.ReplaceAllString(snake, "${1}_${2}")
+	return strings.ToLower(snake)
+}
+
+// TerraformName is used to convert rule name into valid name of the exported data source
+// Current implementation is not covering all the cases defined in the terraform specification
+// https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md#identifiers and http://unicode.org/reports/tr31/ ,
+// but only a reasonable subset.
+func TerraformName(str string) string {
+	str = nameRegexp.ReplaceAllString(str, "-")
+	return ToSnakeCase(str)
+}

--- a/pkg/tools/name_test.go
+++ b/pkg/tools/name_test.go
@@ -1,0 +1,34 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNotations(t *testing.T) {
+	tests := map[string]struct {
+		given    string
+		expected string
+	}{
+		"basic": {
+			given:    "test name ",
+			expected: "test_name",
+		},
+		"multiple words with numbers": {
+			given:    "word test 1 hello2",
+			expected: "word_test_1_hello2",
+		},
+		"capitalized words": {
+			given:    "TestNameHello1 world",
+			expected: "test_name_hello1_world",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := TerraformName(test.given)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
## Version 1.16.0 (July 16, 2024)

### Features/Enhancements
* Migrated go version to 1.21.12 for builds.

* [IMPORTANT] Cloud Access Manager
  * Added command `export-cloudaccess` which allows export of `akamai_cloudaccess_key` resource

* PAPI
  * If edgehostname uses custom TTL, it is exported in the `akamai_edge_hostname` resource
  * Added support for new rule format `v2024-05-31`