### PR TITLE
Release/v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,77 +1,19 @@
 # RELEASE NOTES
 
-## X.XX.X (Month XX, XXXX)
-
+## 2.8.0 (Feb 25, 2026)
 
 ### FEATURES/ENHANCEMENTS:
 
-* PAPI
-  * Added support for the new rule format `v2026-01-09`.
-  * Removed the `secret_key` and `api_key` attributes and introduced support for the `api_key_cam_guid`, `additional_headers_mode`, and `additional_headers_list` attributes in the `akamai_property_rule_formats` data source for the rule formats `v2025-05-30`, `v2025-07-07`, `v2025-09-09` and `v2025-10-16`.
+* ClientLists
+  * Removed `version` from the `akamai_clientlist_activation` template because the `version` attribute is marked now in the schema as `Computed` instead of `Required`.
 
 * Cloud Certificates (Beta)
-  * Added `lifecycle { create_before_destroy = true }` to the `akamai_cloudcertificates_certificate` resource template.
+  * Added the `lifecycle { create_before_destroy = true }` block to the `akamai_cloudcertificates_certificate` resource template.
 
-* ClientLists
-  * Remove `version` in the `akamai_clientlist_activation` template because `version` attribute is marked in schema as `Computed` instead of `Required`.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-### BUG FIXES:
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-### DEPRECATIONS:
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+* PAPI
+  * Added support for the new rule format `v2026-01-09`.
+  * Removed the `secret_key` and `api_key` attributes and introduced support for the `api_key_cam_guid`, `additional_headers_mode`, and `additional_headers_list` attributes 
+    in the `visitor_prioritization_queue_it` behavior when working with rules in JSON or the `akamai_property_rules_builder` data source using these rule formats: `v2025-05-30`, `v2025-07-07`, `v2025-09-09`, and `v2025-10-16`.
 
 ## 2.7.0 (Jan 21, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## X.XX.X (Month XX, XXXX)
 
+
 ### FEATURES/ENHANCEMENTS:
 
-
-
+* PAPI
+  * Added support for the new rule format `v2026-01-09`.
+  * Removed the `secret_key` and `api_key` attributes and introduced support for the `api_key_cam_guid`, `additional_headers_mode`, and `additional_headers_list` attributes in the `akamai_property_rule_formats` data source for the rule formats `v2025-05-30`, `v2025-07-07`, `v2025-09-09` and `v2025-10-16`.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   * Added support for the new rule format `v2026-01-09`.
   * Removed the `secret_key` and `api_key` attributes and introduced support for the `api_key_cam_guid`, `additional_headers_mode`, and `additional_headers_list` attributes in the `akamai_property_rule_formats` data source for the rule formats `v2025-05-30`, `v2025-07-07`, `v2025-09-09` and `v2025-10-16`.
 
+* Cloud Certificates (Beta)
+  * Added `lifecycle { create_before_destroy = true }` to the `akamai_cloudcertificates_certificate` resource template.
+
 * ClientLists
   * Remove `version` in the `akamai_clientlist_activation` template because `version` attribute is marked in schema as `Computed` instead of `Required`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## 2.8.0 (Feb 25, 2026)
 
-### BUG FIXES:
-
-* PAPI
-  * Fixed a typo in the exported `ccm_certificates` block for the `akamai_property` resource: renamed `ecdasa_cert_id` to `ecdsa_cert_id` to match the provider schema.
-
 ### FEATURES/ENHANCEMENTS:
 
 * ClientLists
@@ -19,6 +14,11 @@
   * Added support for the new rule format `v2026-01-09`.
   * Removed the `secret_key` and `api_key` attributes and introduced support for the `api_key_cam_guid`, `additional_headers_mode`, and `additional_headers_list` attributes 
     in the `visitor_prioritization_queue_it` behavior when working with rules in JSON or the `akamai_property_rules_builder` data source using these rule formats: `v2025-05-30`, `v2025-07-07`, `v2025-09-09`, and `v2025-10-16`.
+
+### BUG FIXES:
+
+* PAPI
+  * Fixed a typo in the exported `ccm_certificates` block for the `akamai_property` resource: renamed `ecdasa_cert_id` to `ecdsa_cert_id` to match the provider schema.
 
 ## 2.7.0 (Jan 21, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2.8.0 (Feb 25, 2026)
 
+### BUG FIXES:
+
+* PAPI
+  * Fixed a typo in the exported `ccm_certificates` block for the `akamai_property` resource: renamed `ecdasa_cert_id` to `ecdsa_cert_id` to match the provider schema.
+
 ### FEATURES/ENHANCEMENTS:
 
 * ClientLists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,72 @@
 # RELEASE NOTES
 
+## X.XX.X (Month XX, XXXX)
+
+### FEATURES/ENHANCEMENTS:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+### BUG FIXES:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+### DEPRECATIONS:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 ## 2.7.0 (Jan 21, 2026)
 
 ### FEATURES/ENHANCEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
   * Added support for the new rule format `v2026-01-09`.
   * Removed the `secret_key` and `api_key` attributes and introduced support for the `api_key_cam_guid`, `additional_headers_mode`, and `additional_headers_list` attributes in the `akamai_property_rule_formats` data source for the rule formats `v2025-05-30`, `v2025-07-07`, `v2025-09-09` and `v2025-10-16`.
 
-
+* ClientLists
+  * Remove `version` in the `akamai_clientlist_activation` template because `version` attribute is marked in schema as `Computed` instead of `Required`.
 
 
 

--- a/build/docker_jenkins.bash
+++ b/build/docker_jenkins.bash
@@ -91,7 +91,7 @@ docker exec akatf-container sh -c 'cd edgegrid; git checkout ${EDGEGRID_BRANCH_N
                                    cd ../cli; git checkout ${CLI_BRANCH_NAME};
                                    go mod tidy;
                                    cd ../cli-terraform; git checkout ${CLI_TERRAFORM_BRANCH_NAME};
-                                   go mod edit -replace github.com/akamai/AkamaiOPEN-edgegrid-golang/v12=../edgegrid;
+                                   go mod edit -replace github.com/akamai/AkamaiOPEN-edgegrid-golang/v13=../edgegrid;
                                    go mod edit -replace github.com/akamai/cli/v2=../cli;
                                    go mod tidy'
 

--- a/cli.json
+++ b/cli.json
@@ -1,11 +1,11 @@
 {
   "requirements": {
-    "go": "1.24.10"
+    "go": "1.24.11"
   },
   "commands": [
     {
       "name": "terraform",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "description": "Export selected resources for faster adoption in Terraform",
       "bin": "https://github.com/akamai/cli-terraform/releases/download/v{{.Version}}/akamai-{{.Name}}-{{.Version}}-{{.OS}}{{.Arch}}{{.BinSuffix}}",
       "auto-complete": true,

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	// Version holds current version of cli-terraform
-	Version = "2.7.0"
+	Version = "2.8.0"
 )
 
 // Run initializes the cli and runs it

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"os"
 
-	sesslog "github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/log"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/session"
+	sesslog "github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/log"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/session"
 	"github.com/akamai/cli-terraform/v2/pkg/commands"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	akacli "github.com/akamai/cli/v2/pkg/app"

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -6,7 +6,7 @@ import (
 	"flag"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/session"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/session"
 	"github.com/akamai/cli/v2/pkg/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli/v2"

--- a/go.mod
+++ b/go.mod
@@ -61,4 +61,4 @@ require (
 
 //replace github.com/akamai/AkamaiOPEN-edgegrid-golang/v12 => ../akamaiopen-edgegrid-golang
 //replace github.com/akamai/cli/v2 => ../cli
-replace gopkg.in/yaml.v2 v2.2.2 => gopkg.in/yaml.v2 v2.4.0 // Fix security vulnerability
+replace github.com/stretchr/testify v1.4.0 => github.com/stretchr/testify v1.10.0 // Fix security vulnerability

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/akamai/cli-terraform/v2
 go 1.24.11
 
 require (
-	github.com/akamai/AkamaiOPEN-edgegrid-golang/v12 v12.3.0
+	github.com/akamai/AkamaiOPEN-edgegrid-golang/v13 v13.0.0
 	github.com/akamai/cli/v2 v2.0.3
 	github.com/fatih/color v1.18.0
 	github.com/hashicorp/hcl/v2 v2.23.0
@@ -59,6 +59,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-//replace github.com/akamai/AkamaiOPEN-edgegrid-golang/v12 => ../akamaiopen-edgegrid-golang
+//replace github.com/akamai/AkamaiOPEN-edgegrid-golang/v13 => ../akamaiopen-edgegrid-golang
 //replace github.com/akamai/cli/v2 => ../cli
 replace github.com/stretchr/testify v1.4.0 => github.com/stretchr/testify v1.10.0 // Fix security vulnerability

--- a/go.sum
+++ b/go.sum
@@ -96,10 +96,16 @@ github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMT
 github.com/spf13/cast v1.7.0 h1:ntdiHjuueXFgm5nzDRdOS4yfT43P5Fnud6DH50rz/7w=
 github.com/spf13/cast v1.7.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/objx v0.5.3 h1:jmXUvGomnU1o3W/V5h2VEradbpJDwGrzugQQvL0POH4=
 github.com/stretchr/objx v0.5.3/go.mod h1:rDQraq+vQZU7Fde9LOZLr8Tax6zZvy4kuNKF+QYS+U0=
-github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/urfave/cli/v2 v2.19.3 h1:GsJ5D2qZWF6hk/F276qqf8v/Ff4IzAUTB+CUFSNhN6M=
@@ -165,7 +171,6 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/akamai/AkamaiOPEN-edgegrid-golang/v12 v12.3.0 h1:iGVPe/gPqzpXggbbmVLWR0TyJ9UoPoqKL+kspjseZzE=
-github.com/akamai/AkamaiOPEN-edgegrid-golang/v12 v12.3.0/go.mod h1:76JtkiCKMwTdTOlKe9goT4Md+oWjfMouGBQgy+u1bgc=
+github.com/akamai/AkamaiOPEN-edgegrid-golang/v13 v13.0.0 h1:1YZQwsBHpgzfsTCM/Hb9Kakc+4lAe060EidhUb8wW68=
+github.com/akamai/AkamaiOPEN-edgegrid-golang/v13 v13.0.0/go.mod h1:lnGMNS5JOiZWnZT5nv+dG8fC92X5U98DiIIPNpwlQQY=
 github.com/akamai/cli/v2 v2.0.3 h1:kH5cchT9bb3wMD8XTF5M6NxxScyfEq5s41gHnflPR9I=
 github.com/akamai/cli/v2 v2.0.3/go.mod h1:fsyrhFLTPIpsL1t2GNrm59oRNFp6f/qe0uCZnUp94As=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=

--- a/pkg/commands/validation.go
+++ b/pkg/commands/validation.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"slices"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/papi"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/papi"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli/v2/pkg/color"
 	"github.com/urfave/cli/v2"

--- a/pkg/commands/validation_test.go
+++ b/pkg/commands/validation_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/papi"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/papi"
 	"github.com/akamai/cli/v2/pkg/color"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"

--- a/pkg/edgegrid/config.go
+++ b/pkg/edgegrid/config.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/edgegrid"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/session"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/edgegrid"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/session"
 	"github.com/urfave/cli/v2"
 )
 

--- a/pkg/edgegrid/config_test.go
+++ b/pkg/edgegrid/config_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/edgegrid"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/ptr"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/session"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/edgegrid"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/ptr"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/session"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"

--- a/pkg/edgegrid/session.go
+++ b/pkg/edgegrid/session.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	sesslog "github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/log"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/session"
+	sesslog "github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/log"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/session"
 	"github.com/akamai/cli/v2/pkg/log"
 	"github.com/urfave/cli/v2"
 )

--- a/pkg/edgegrid/session_test.go
+++ b/pkg/edgegrid/session_test.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/session"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/session"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"

--- a/pkg/providers/apidefinitions/create_apidefinition.go
+++ b/pkg/providers/apidefinitions/create_apidefinition.go
@@ -13,9 +13,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/apidefinitions"
-	v0 "github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/apidefinitions/v0"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/ptr"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/apidefinitions"
+	v0 "github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/apidefinitions/v0"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/ptr"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"

--- a/pkg/providers/apidefinitions/create_apidefinition_test.go
+++ b/pkg/providers/apidefinitions/create_apidefinition_test.go
@@ -9,9 +9,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/apidefinitions"
-	v0 "github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/apidefinitions/v0"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/ptr"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/apidefinitions"
+	v0 "github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/apidefinitions/v0"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/ptr"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli/v2/pkg/terminal"
 	"github.com/stretchr/testify/assert"

--- a/pkg/providers/appsec/create_appsec.go
+++ b/pkg/providers/appsec/create_appsec.go
@@ -12,8 +12,8 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/appsec"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/botman"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/appsec"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/botman"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"

--- a/pkg/providers/appsec/create_appsec_test.go
+++ b/pkg/providers/appsec/create_appsec_test.go
@@ -11,8 +11,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/appsec"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/botman"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/appsec"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/botman"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"
 

--- a/pkg/providers/clientlists/create_clientlist.go
+++ b/pkg/providers/clientlists/create_clientlist.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/clientlists"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/clientlists"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"

--- a/pkg/providers/clientlists/create_clientlist_test.go
+++ b/pkg/providers/clientlists/create_clientlist_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/clientlists"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/clientlists"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli/v2/pkg/terminal"
 	"github.com/stretchr/testify/assert"

--- a/pkg/providers/clientlists/templates/client-list.tmpl
+++ b/pkg/providers/clientlists/templates/client-list.tmpl
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 5.4.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/clientlists/templates/client-list.tmpl
+++ b/pkg/providers/clientlists/templates/client-list.tmpl
@@ -40,7 +40,6 @@ resource "akamai_clientlist_list" "list_{{.ClientList.ListID}}" {
 {{if .ClientList.StagingActivation.HasActivation}}
 resource "akamai_clientlist_activation" "activation_{{.ClientList.ListID}}_STAGING" {
   list_id                 = akamai_clientlist_list.list_{{.ClientList.ListID}}.list_id
-  version                 = akamai_clientlist_list.list_{{.ClientList.ListID}}.version
   network                 = "STAGING"
   comments                = "{{.ClientList.StagingActivation.Comments}}"
   notification_recipients = [{{range $index, $element := .ClientList.StagingActivation.NotificationRecipients}}{{if $index}}, {{end}}"{{$element}}"{{end}}]
@@ -49,7 +48,6 @@ resource "akamai_clientlist_activation" "activation_{{.ClientList.ListID}}_STAGI
 {{- else}}
 # resource "akamai_clientlist_activation" "activation_{{.ClientList.ListID}}_STAGING" {
 #   list_id                 = akamai_clientlist_list.list_{{.ClientList.ListID}}.list_id
-#   version                 = akamai_clientlist_list.list_{{.ClientList.ListID}}.version
 #   network                 = "STAGING"
 #   comments                = ""
 #   notification_recipients = []
@@ -59,7 +57,6 @@ resource "akamai_clientlist_activation" "activation_{{.ClientList.ListID}}_STAGI
 {{if .ClientList.ProductionActivation.HasActivation}}
 resource "akamai_clientlist_activation" "activation_{{.ClientList.ListID}}_PRODUCTION" {
   list_id                 = akamai_clientlist_list.list_{{.ClientList.ListID}}.list_id
-  version                 = akamai_clientlist_list.list_{{.ClientList.ListID}}.version
   network                 = "PRODUCTION"
   comments                = "{{.ClientList.ProductionActivation.Comments}}"
   notification_recipients = [{{range $index, $element := .ClientList.ProductionActivation.NotificationRecipients}}{{if $index}}, {{end}}"{{$element}}"{{end}}]
@@ -68,7 +65,6 @@ resource "akamai_clientlist_activation" "activation_{{.ClientList.ListID}}_PRODU
 {{- else }}
 # resource "akamai_clientlist_activation" "activation_{{.ClientList.ListID}}_PRODUCTION" {
 #   list_id                 = akamai_clientlist_list.list_{{.ClientList.ListID}}.list_id
-#   version                 = akamai_clientlist_list.list_{{.ClientList.ListID}}.version
 #   network                 = "PRODUCTION"
 #   comments                = ""
 #   notification_recipients = []

--- a/pkg/providers/clientlists/testdata/active_list/client-list.tf
+++ b/pkg/providers/clientlists/testdata/active_list/client-list.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 5.4.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/clientlists/testdata/active_list/client-list.tf
+++ b/pkg/providers/clientlists/testdata/active_list/client-list.tf
@@ -25,7 +25,6 @@ resource "akamai_clientlist_list" "list_123_ABC" {
 
 resource "akamai_clientlist_activation" "activation_123_ABC_STAGING" {
   list_id                 = akamai_clientlist_list.list_123_ABC.list_id
-  version                 = akamai_clientlist_list.list_123_ABC.version
   network                 = "STAGING"
   comments                = "Staging Activation"
   notification_recipients = ["a@b.com", "c@d.com"]
@@ -34,7 +33,6 @@ resource "akamai_clientlist_activation" "activation_123_ABC_STAGING" {
 
 resource "akamai_clientlist_activation" "activation_123_ABC_PRODUCTION" {
   list_id                 = akamai_clientlist_list.list_123_ABC.list_id
-  version                 = akamai_clientlist_list.list_123_ABC.version
   network                 = "PRODUCTION"
   comments                = "Production Activation"
   notification_recipients = ["1@2.com", "3@4.com"]

--- a/pkg/providers/clientlists/testdata/empty_list/client-list.tf
+++ b/pkg/providers/clientlists/testdata/empty_list/client-list.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 5.4.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/clientlists/testdata/empty_list/client-list.tf
+++ b/pkg/providers/clientlists/testdata/empty_list/client-list.tf
@@ -25,7 +25,6 @@ resource "akamai_clientlist_list" "list_123_ABC" {
 
 # resource "akamai_clientlist_activation" "activation_123_ABC_STAGING" {
 #   list_id                 = akamai_clientlist_list.list_123_ABC.list_id
-#   version                 = akamai_clientlist_list.list_123_ABC.version
 #   network                 = "STAGING"
 #   comments                = ""
 #   notification_recipients = []
@@ -34,7 +33,6 @@ resource "akamai_clientlist_list" "list_123_ABC" {
 
 # resource "akamai_clientlist_activation" "activation_123_ABC_PRODUCTION" {
 #   list_id                 = akamai_clientlist_list.list_123_ABC.list_id
-#   version                 = akamai_clientlist_list.list_123_ABC.version
 #   network                 = "PRODUCTION"
 #   comments                = ""
 #   notification_recipients = []

--- a/pkg/providers/clientlists/testdata/list_with_items/client-list.tf
+++ b/pkg/providers/clientlists/testdata/list_with_items/client-list.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 5.4.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/clientlists/testdata/list_with_items/client-list.tf
+++ b/pkg/providers/clientlists/testdata/list_with_items/client-list.tf
@@ -36,7 +36,6 @@ resource "akamai_clientlist_list" "list_123_ABC" {
 
 # resource "akamai_clientlist_activation" "activation_123_ABC_STAGING" {
 #   list_id                 = akamai_clientlist_list.list_123_ABC.list_id
-#   version                 = akamai_clientlist_list.list_123_ABC.version
 #   network                 = "STAGING"
 #   comments                = ""
 #   notification_recipients = []
@@ -45,7 +44,6 @@ resource "akamai_clientlist_list" "list_123_ABC" {
 
 # resource "akamai_clientlist_activation" "activation_123_ABC_PRODUCTION" {
 #   list_id                 = akamai_clientlist_list.list_123_ABC.list_id
-#   version                 = akamai_clientlist_list.list_123_ABC.version
 #   network                 = "PRODUCTION"
 #   comments                = ""
 #   notification_recipients = []

--- a/pkg/providers/cloudaccess/create_key.go
+++ b/pkg/providers/cloudaccess/create_key.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/cloudaccess"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/cloudaccess"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"

--- a/pkg/providers/cloudaccess/create_key_test.go
+++ b/pkg/providers/cloudaccess/create_key_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/cloudaccess"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/cloudaccess"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"
 	"github.com/akamai/cli/v2/pkg/terminal"

--- a/pkg/providers/cloudcertificates/create_cloudcertificates_certificate.go
+++ b/pkg/providers/cloudcertificates/create_cloudcertificates_certificate.go
@@ -11,7 +11,7 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/cloudcertificates"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/cloudcertificates"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"

--- a/pkg/providers/cloudcertificates/create_cloudcertificates_certificate_test.go
+++ b/pkg/providers/cloudcertificates/create_cloudcertificates_certificate_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/cloudcertificates"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/ptr"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/cloudcertificates"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/ptr"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli/v2/pkg/terminal"
 	"github.com/stretchr/testify/assert"

--- a/pkg/providers/cloudcertificates/templates/cloudcertificate.tmpl
+++ b/pkg/providers/cloudcertificates/templates/cloudcertificate.tmpl
@@ -40,6 +40,10 @@ resource "akamai_cloudcertificates_certificate" "{{ .Certificate.ResourceName }}
   {{- end}}
   }
   {{- end}}
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 {{- /* Conditional logic for signed certificate upload depending on certificate status */}}

--- a/pkg/providers/cloudcertificates/templates/cloudcertificate.tmpl
+++ b/pkg/providers/cloudcertificates/templates/cloudcertificate.tmpl
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/cloudcertificates/testdata/active/cloudcertificate.tf
+++ b/pkg/providers/cloudcertificates/testdata/active/cloudcertificate.tf
@@ -27,6 +27,10 @@ resource "akamai_cloudcertificates_certificate" "test-name_example_com1234567890
     state        = "CA"
     locality     = "Test City"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "akamai_cloudcertificates_upload_signed_certificate" "test-name_example_com1234567890" {

--- a/pkg/providers/cloudcertificates/testdata/active/cloudcertificate.tf
+++ b/pkg/providers/cloudcertificates/testdata/active/cloudcertificate.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/cloudcertificates/testdata/active_custom_edgerc_section/cloudcertificate.tf
+++ b/pkg/providers/cloudcertificates/testdata/active_custom_edgerc_section/cloudcertificate.tf
@@ -27,6 +27,10 @@ resource "akamai_cloudcertificates_certificate" "test-name_example_com1234567890
     state        = "CA"
     locality     = "Test City"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "akamai_cloudcertificates_upload_signed_certificate" "test-name_example_com1234567890" {

--- a/pkg/providers/cloudcertificates/testdata/active_custom_edgerc_section/cloudcertificate.tf
+++ b/pkg/providers/cloudcertificates/testdata/active_custom_edgerc_section/cloudcertificate.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/cloudcertificates/testdata/active_pems_end_in_double_newline/cloudcertificate.tf
+++ b/pkg/providers/cloudcertificates/testdata/active_pems_end_in_double_newline/cloudcertificate.tf
@@ -27,6 +27,10 @@ resource "akamai_cloudcertificates_certificate" "test-name_example_com1234567890
     state        = "CA"
     locality     = "Test City"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "akamai_cloudcertificates_upload_signed_certificate" "test-name_example_com1234567890" {

--- a/pkg/providers/cloudcertificates/testdata/active_pems_end_in_double_newline/cloudcertificate.tf
+++ b/pkg/providers/cloudcertificates/testdata/active_pems_end_in_double_newline/cloudcertificate.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/cloudcertificates/testdata/active_pems_end_in_newline/cloudcertificate.tf
+++ b/pkg/providers/cloudcertificates/testdata/active_pems_end_in_newline/cloudcertificate.tf
@@ -27,6 +27,10 @@ resource "akamai_cloudcertificates_certificate" "test-name_example_com1234567890
     state        = "CA"
     locality     = "Test City"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "akamai_cloudcertificates_upload_signed_certificate" "test-name_example_com1234567890" {

--- a/pkg/providers/cloudcertificates/testdata/active_pems_end_in_newline/cloudcertificate.tf
+++ b/pkg/providers/cloudcertificates/testdata/active_pems_end_in_newline/cloudcertificate.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/cloudcertificates/testdata/csr_ready/cloudcertificate.tf
+++ b/pkg/providers/cloudcertificates/testdata/csr_ready/cloudcertificate.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/cloudcertificates/testdata/csr_ready/cloudcertificate.tf
+++ b/pkg/providers/cloudcertificates/testdata/csr_ready/cloudcertificate.tf
@@ -27,6 +27,10 @@ resource "akamai_cloudcertificates_certificate" "test-name_example_com1234567890
     state        = "CA"
     locality     = "Test City"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 /*

--- a/pkg/providers/cloudcertificates/testdata/empty_subject/cloudcertificate.tf
+++ b/pkg/providers/cloudcertificates/testdata/empty_subject/cloudcertificate.tf
@@ -20,6 +20,10 @@ resource "akamai_cloudcertificates_certificate" "test-name_example_com1234567890
   key_type       = "RSA"
   secure_network = "ENHANCED_TLS"
   sans           = ["test.example.com", "test.example2.com"]
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "akamai_cloudcertificates_upload_signed_certificate" "test-name_example_com1234567890" {

--- a/pkg/providers/cloudcertificates/testdata/empty_subject/cloudcertificate.tf
+++ b/pkg/providers/cloudcertificates/testdata/empty_subject/cloudcertificate.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/cloudcertificates/testdata/name_begins_with_dot/cloudcertificate.tf
+++ b/pkg/providers/cloudcertificates/testdata/name_begins_with_dot/cloudcertificate.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/cloudcertificates/testdata/name_begins_with_dot/cloudcertificate.tf
+++ b/pkg/providers/cloudcertificates/testdata/name_begins_with_dot/cloudcertificate.tf
@@ -27,6 +27,10 @@ resource "akamai_cloudcertificates_certificate" "_test-name_example_com123456789
     state        = "CA"
     locality     = "Test City"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "akamai_cloudcertificates_upload_signed_certificate" "_test-name_example_com1234567890" {

--- a/pkg/providers/cloudcertificates/testdata/name_begins_with_number/cloudcertificate.tf
+++ b/pkg/providers/cloudcertificates/testdata/name_begins_with_number/cloudcertificate.tf
@@ -27,6 +27,10 @@ resource "akamai_cloudcertificates_certificate" "_123test-name_example_com123456
     state        = "CA"
     locality     = "Test City"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "akamai_cloudcertificates_upload_signed_certificate" "_123test-name_example_com1234567890" {

--- a/pkg/providers/cloudcertificates/testdata/name_begins_with_number/cloudcertificate.tf
+++ b/pkg/providers/cloudcertificates/testdata/name_begins_with_number/cloudcertificate.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/cloudcertificates/testdata/ready_for_use/cloudcertificate.tf
+++ b/pkg/providers/cloudcertificates/testdata/ready_for_use/cloudcertificate.tf
@@ -27,6 +27,10 @@ resource "akamai_cloudcertificates_certificate" "test-name_example_com1234567890
     state        = "CA"
     locality     = "Test City"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "akamai_cloudcertificates_upload_signed_certificate" "test-name_example_com1234567890" {

--- a/pkg/providers/cloudcertificates/testdata/ready_for_use/cloudcertificate.tf
+++ b/pkg/providers/cloudcertificates/testdata/ready_for_use/cloudcertificate.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/cloudcertificates/testdata/ready_for_use_no_trust_chain/cloudcertificate.tf
+++ b/pkg/providers/cloudcertificates/testdata/ready_for_use_no_trust_chain/cloudcertificate.tf
@@ -27,6 +27,10 @@ resource "akamai_cloudcertificates_certificate" "test-name_example_com1234567890
     state        = "CA"
     locality     = "Test City"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "akamai_cloudcertificates_upload_signed_certificate" "test-name_example_com1234567890" {

--- a/pkg/providers/cloudcertificates/testdata/ready_for_use_no_trust_chain/cloudcertificate.tf
+++ b/pkg/providers/cloudcertificates/testdata/ready_for_use_no_trust_chain/cloudcertificate.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/cloudlets/create_policy.go
+++ b/pkg/providers/cloudlets/create_policy.go
@@ -11,8 +11,8 @@ import (
 	"sort"
 	"text/template"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/cloudlets"
-	v3 "github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/cloudlets/v3"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/cloudlets"
+	v3 "github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/cloudlets/v3"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"

--- a/pkg/providers/cloudlets/create_policy_test.go
+++ b/pkg/providers/cloudlets/create_policy_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/cloudlets"
-	v3 "github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/cloudlets/v3"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/cloudlets"
+	v3 "github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/cloudlets/v3"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"
 	"github.com/akamai/cli/v2/pkg/terminal"

--- a/pkg/providers/cloudwrapper/create_configuration.go
+++ b/pkg/providers/cloudwrapper/create_configuration.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/cloudwrapper"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/cloudwrapper"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"

--- a/pkg/providers/cloudwrapper/create_configuration_test.go
+++ b/pkg/providers/cloudwrapper/create_configuration_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/cloudwrapper"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/cloudwrapper"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"
 	"github.com/akamai/cli/v2/pkg/terminal"

--- a/pkg/providers/cps/create_cps.go
+++ b/pkg/providers/cps/create_cps.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/cps"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/cps"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"

--- a/pkg/providers/cps/create_cps_test.go
+++ b/pkg/providers/cps/create_cps_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/cps"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/ptr"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/cps"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/ptr"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli/v2/pkg/terminal"
 	"github.com/jinzhu/copier"

--- a/pkg/providers/dns/command_create_zone.go
+++ b/pkg/providers/dns/command_create_zone.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/dns"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/dns"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"
 	"github.com/akamai/cli/v2/pkg/color"

--- a/pkg/providers/dns/template_processing.go
+++ b/pkg/providers/dns/template_processing.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/dns"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/dns"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"
 )
 

--- a/pkg/providers/dns/tf_recordsets.go
+++ b/pkg/providers/dns/tf_recordsets.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/dns"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/dns"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"
 	"github.com/shirou/gopsutil/mem"
 )

--- a/pkg/providers/dns/tf_recordsets_test.go
+++ b/pkg/providers/dns/tf_recordsets_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/dns"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/dns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/pkg/providers/dns/tf_zone.go
+++ b/pkg/providers/dns/tf_zone.go
@@ -3,7 +3,7 @@ package dns
 import (
 	"context"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/dns"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/dns"
 )
 
 // process zone

--- a/pkg/providers/dns/tf_zone_test.go
+++ b/pkg/providers/dns/tf_zone_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/dns"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/dns"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/providers/domainownership/create_domainownership.go
+++ b/pkg/providers/domainownership/create_domainownership.go
@@ -10,7 +10,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/domainownership"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/domainownership"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"

--- a/pkg/providers/domainownership/create_domainownership_test.go
+++ b/pkg/providers/domainownership/create_domainownership_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/domainownership"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/ptr"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/domainownership"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/ptr"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli/v2/pkg/terminal"
 	"github.com/stretchr/testify/assert"

--- a/pkg/providers/edgeworkers/create_edgekv.go
+++ b/pkg/providers/edgeworkers/create_edgekv.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/edgeworkers"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/edgeworkers"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"

--- a/pkg/providers/edgeworkers/create_edgekv_test.go
+++ b/pkg/providers/edgeworkers/create_edgekv_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/edgeworkers"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/edgeworkers"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"
 	"github.com/akamai/cli/v2/pkg/terminal"

--- a/pkg/providers/edgeworkers/create_edgeworker.go
+++ b/pkg/providers/edgeworkers/create_edgeworker.go
@@ -13,7 +13,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/edgeworkers"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/edgeworkers"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"

--- a/pkg/providers/edgeworkers/create_edgeworker_test.go
+++ b/pkg/providers/edgeworkers/create_edgeworker_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/edgeworkers"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/edgeworkers"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"
 	"github.com/akamai/cli/v2/pkg/terminal"

--- a/pkg/providers/gtm/create_domain.go
+++ b/pkg/providers/gtm/create_domain.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/gtm"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/gtm"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"

--- a/pkg/providers/gtm/create_domain_test.go
+++ b/pkg/providers/gtm/create_domain_test.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/gtm"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/gtm"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"
 	"github.com/akamai/cli/v2/pkg/terminal"

--- a/pkg/providers/iam/create_iam.go
+++ b/pkg/providers/iam/create_iam.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/iam"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/iam"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"
 	"github.com/akamai/cli/v2/pkg/terminal"
 	"github.com/urfave/cli/v2"

--- a/pkg/providers/iam/create_iam_all.go
+++ b/pkg/providers/iam/create_iam_all.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/iam"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/iam"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"

--- a/pkg/providers/iam/create_iam_all_test.go
+++ b/pkg/providers/iam/create_iam_all_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/iam"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/ptr"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/iam"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/ptr"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"
 	"github.com/akamai/cli/v2/pkg/terminal"

--- a/pkg/providers/iam/create_iam_allowlist.go
+++ b/pkg/providers/iam/create_iam_allowlist.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/iam"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/iam"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"

--- a/pkg/providers/iam/create_iam_allowlist_test.go
+++ b/pkg/providers/iam/create_iam_allowlist_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/iam"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/ptr"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/iam"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/ptr"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli/v2/pkg/terminal"
 	"github.com/stretchr/testify/assert"

--- a/pkg/providers/iam/create_iam_client.go
+++ b/pkg/providers/iam/create_iam_client.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/iam"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/iam"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"

--- a/pkg/providers/iam/create_iam_client_test.go
+++ b/pkg/providers/iam/create_iam_client_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/iam"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/iam"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"
 	"github.com/akamai/cli/v2/pkg/terminal"

--- a/pkg/providers/iam/create_iam_group.go
+++ b/pkg/providers/iam/create_iam_group.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/iam"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/iam"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"

--- a/pkg/providers/iam/create_iam_group_test.go
+++ b/pkg/providers/iam/create_iam_group_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/iam"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/iam"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"
 	"github.com/akamai/cli/v2/pkg/terminal"

--- a/pkg/providers/iam/create_iam_role.go
+++ b/pkg/providers/iam/create_iam_role.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/iam"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/iam"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"

--- a/pkg/providers/iam/create_iam_role_test.go
+++ b/pkg/providers/iam/create_iam_role_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/iam"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/iam"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"
 	"github.com/akamai/cli/v2/pkg/terminal"

--- a/pkg/providers/iam/create_iam_test.go
+++ b/pkg/providers/iam/create_iam_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/iam"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/iam"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/providers/iam/create_iam_user.go
+++ b/pkg/providers/iam/create_iam_user.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/iam"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/iam"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"

--- a/pkg/providers/iam/create_iam_user_test.go
+++ b/pkg/providers/iam/create_iam_user_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/iam"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/iam"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"
 	"github.com/akamai/cli/v2/pkg/terminal"

--- a/pkg/providers/imaging/create_imaging.go
+++ b/pkg/providers/imaging/create_imaging.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/imaging"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/imaging"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"

--- a/pkg/providers/imaging/create_imaging_test.go
+++ b/pkg/providers/imaging/create_imaging_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/imaging"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/ptr"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/imaging"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/ptr"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli/v2/pkg/terminal"
 	"github.com/stretchr/testify/assert"

--- a/pkg/providers/mtlskeystore/create_certificate.go
+++ b/pkg/providers/mtlskeystore/create_certificate.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/mtlskeystore"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/mtlskeystore"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"

--- a/pkg/providers/mtlskeystore/create_certificate_test.go
+++ b/pkg/providers/mtlskeystore/create_certificate_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/mtlskeystore"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/ptr"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/mtlskeystore"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/ptr"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"
 	"github.com/akamai/cli/v2/pkg/terminal"

--- a/pkg/providers/mtlstruststore/create_ca_set.go
+++ b/pkg/providers/mtlstruststore/create_ca_set.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/mtlstruststore"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/mtlstruststore"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"

--- a/pkg/providers/mtlstruststore/create_ca_set_test.go
+++ b/pkg/providers/mtlstruststore/create_ca_set_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/mtlstruststore"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/ptr"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/mtlstruststore"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/ptr"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli/v2/pkg/terminal"
 	"github.com/stretchr/testify/assert"

--- a/pkg/providers/papi/create_include.go
+++ b/pkg/providers/papi/create_include.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/papi"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/ptr"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/papi"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/ptr"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"

--- a/pkg/providers/papi/create_include_test.go
+++ b/pkg/providers/papi/create_include_test.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/papi"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/ptr"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/papi"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/ptr"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli/v2/pkg/terminal"
 	"github.com/stretchr/testify/assert"

--- a/pkg/providers/papi/create_property.go
+++ b/pkg/providers/papi/create_property.go
@@ -15,9 +15,9 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/hapi"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/papi"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/ptr"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/hapi"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/papi"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/ptr"
 	"github.com/akamai/cli-terraform/v2/pkg/edgegrid"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"

--- a/pkg/providers/papi/create_property_test.go
+++ b/pkg/providers/papi/create_property_test.go
@@ -263,7 +263,7 @@ func TestCreateProperty(t *testing.T) {
 		PropertyVersion: 5,
 		Etag:            "4607f363da8bc05b0c0f0f7524985d2fbc5d864d",
 		Hostnames: papi.HostnameResponseItems{
-			Items: []papi.Hostname{
+			Items: []papi.HostnameResponseItem{
 				{
 					CnameType:            "EDGE_HOSTNAME",
 					EdgeHostnameID:       "ehn_2867480",
@@ -283,7 +283,7 @@ func TestCreateProperty(t *testing.T) {
 		PropertyVersion: 5,
 		Etag:            "4607f363da8bc05b0c0f0f7524985d2fbc5d864d",
 		Hostnames: papi.HostnameResponseItems{
-			Items: []papi.Hostname{
+			Items: []papi.HostnameResponseItem{
 				{
 					CnameType:            "EDGE_HOSTNAME",
 					EdgeHostnameID:       "ehn_2867480",
@@ -303,7 +303,7 @@ func TestCreateProperty(t *testing.T) {
 		PropertyVersion: 5,
 		Etag:            "4607f363da8bc05b0c0f0f7524985d2fbc5d864d",
 		Hostnames: papi.HostnameResponseItems{
-			Items: []papi.Hostname{
+			Items: []papi.HostnameResponseItem{
 				{
 					CnameType:            "EDGE_HOSTNAME",
 					EdgeHostnameID:       "ehn_2867480",
@@ -317,16 +317,20 @@ func TestCreateProperty(t *testing.T) {
 					CnameFrom:            "foo.com",
 					CnameTo:              "foo.com.edgekey.net",
 					CertProvisioningType: "CCM",
-					CCMCertificates: &papi.CCMCertificates{
-						RSACertID:     "2226",
+					CCMCertificates: &papi.CCMCertificatesResp{
+						CCMCertificates: papi.CCMCertificates{
+							RSACertID:   "2226",
+							ECDSACertID: "7890",
+						},
 						RSACertLink:   "/ccm/v1/certificates/2226",
-						ECDSACertID:   "7890",
 						ECDSACertLink: "/ccm/v1/certificates/7890",
 					},
-					MTLS: &papi.MTLS{
-						CASetID:         "cas_1234567890",
-						CheckClientOCSP: true,
-						SendCASetClient: true,
+					MTLS: &papi.MTLSResp{
+						MTLS: papi.MTLS{
+							CASetID:         "cas_1234567890",
+							CheckClientOCSP: true,
+							SendCASetClient: true,
+						},
 					},
 					TLSConfiguration: &papi.TLSConfiguration{
 						CipherProfile:            "ak-tls-1-3",
@@ -347,7 +351,7 @@ func TestCreateProperty(t *testing.T) {
 		PropertyVersion: 5,
 		Etag:            "4607f363da8bc05b0c0f0f7524985d2fbc5d864d",
 		Hostnames: papi.HostnameResponseItems{
-			Items: []papi.Hostname{
+			Items: []papi.HostnameResponseItem{
 				{
 					CnameType:            "EDGE_HOSTNAME",
 					EdgeHostnameID:       "ehn_2867480",
@@ -361,11 +365,13 @@ func TestCreateProperty(t *testing.T) {
 					CnameFrom:            "foo.com",
 					CnameTo:              "foo.com.edgekey.net",
 					CertProvisioningType: "CCM",
-					CCMCertificates: &papi.CCMCertificates{
-						RSACertID:     "2226",
+					CCMCertificates: &papi.CCMCertificatesResp{
 						RSACertLink:   "/ccm/v1/certificates/2226",
-						ECDSACertID:   "7890",
 						ECDSACertLink: "/ccm/v1/certificates/7890",
+						CCMCertificates: papi.CCMCertificates{
+							RSACertID:   "2226",
+							ECDSACertID: "7890",
+						},
 					},
 					TLSConfiguration: &papi.TLSConfiguration{
 						CipherProfile:            "ak-tls-1-3",
@@ -385,7 +391,7 @@ func TestCreateProperty(t *testing.T) {
 		PropertyVersion: 5,
 		Etag:            "4607f363da8bc05b0c0f0f7524985d2fbc5d864d",
 		Hostnames: papi.HostnameResponseItems{
-			Items: []papi.Hostname{
+			Items: []papi.HostnameResponseItem{
 				{
 					CnameType:            "EDGE_HOSTNAME",
 					EdgeHostnameID:       "ehn_2867480",
@@ -405,7 +411,7 @@ func TestCreateProperty(t *testing.T) {
 		PropertyVersion: 5,
 		Etag:            "4607f363da8bc05b0c0f0f7524985d2fbc5d864d",
 		Hostnames: papi.HostnameResponseItems{
-			Items: []papi.Hostname{
+			Items: []papi.HostnameResponseItem{
 				{
 					CnameType:            "EDGE_HOSTNAME",
 					EdgeHostnameID:       "",
@@ -425,7 +431,7 @@ func TestCreateProperty(t *testing.T) {
 		PropertyVersion: 1,
 		Etag:            "4607f363da8bc05b0c0f0f7524985d2fbc5d864d",
 		Hostnames: papi.HostnameResponseItems{
-			Items: []papi.Hostname{
+			Items: []papi.HostnameResponseItem{
 				{
 					CnameType:            "EDGE_HOSTNAME",
 					EdgeHostnameID:       "ehn_2867480",
@@ -445,7 +451,7 @@ func TestCreateProperty(t *testing.T) {
 		PropertyVersion: 5,
 		Etag:            "4607f363da8bc05b0c0f0f7524985d2fbc5d864d",
 		Hostnames: papi.HostnameResponseItems{
-			Items: []papi.Hostname{
+			Items: []papi.HostnameResponseItem{
 				{
 					CnameType:            "EDGE_HOSTNAME",
 					EdgeHostnameID:       "ehn_2867480",

--- a/pkg/providers/papi/create_property_test.go
+++ b/pkg/providers/papi/create_property_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/hapi"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/papi"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/ptr"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/hapi"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/papi"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v13/pkg/ptr"
 	"github.com/akamai/cli-terraform/v2/pkg/templates"
 	"github.com/akamai/cli-terraform/v2/pkg/tools"
 	"github.com/akamai/cli/v2/pkg/terminal"

--- a/pkg/providers/papi/ruleformats.gen_test.go
+++ b/pkg/providers/papi/ruleformats.gen_test.go
@@ -382,6 +382,26 @@ func TestProcessPolicyTemplatesGenerated(t *testing.T) {
 			filesToCheck: []string{"property.tf", "rules.tf", "variables.tf", "import.sh"},
 			filterFuncs:  []func([]string) ([]string, error){useThisOnlyRuleFormat("v2025-10-16")},
 		},
+		"property with rules as datasource - hcl rules version v2026-01-09": {
+			givenData: TFData{
+				Property: TFPropertyData{
+					GroupName:            "test_group",
+					GroupID:              "grp_12345",
+					ContractID:           "test_contract",
+					PropertyResourceName: "test-edgesuite-net",
+					PropertyName:         "test.edgesuite.net",
+					PropertyID:           "prp_12345",
+					ProductID:            "prd_HTTP_Content_Del",
+					ProductName:          "HTTP_Content_Del",
+					RuleFormat:           "v2026-01-09",
+					IsSecure:             "false",
+					ReadVersion:          "LATEST",
+				},
+			},
+			dir:          "ruleformats/v2026_01_09/rules_datasource",
+			filesToCheck: []string{"property.tf", "rules.tf", "variables.tf", "import.sh"},
+			filterFuncs:  []func([]string) ([]string, error){useThisOnlyRuleFormat("v2026-01-09")},
+		},
 	}
 
 	for name, test := range tests {

--- a/pkg/providers/papi/templates/includes.tmpl
+++ b/pkg/providers/papi/templates/includes.tmpl
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/templates/property.tmpl
+++ b/pkg/providers/papi/templates/property.tmpl
@@ -87,7 +87,7 @@ resource "akamai_property" "{{.Property.PropertyResourceName}}" {
       rsa_cert_id = "{{.RSACertID}}"
       {{- end}}
       {{- if .ECDSACertID}}
-      ecdasa_cert_id = "{{.ECDSACertID}}"
+      ecdsa_cert_id = "{{.ECDSACertID}}"
       {{- end}}
     }
     {{- end}}

--- a/pkg/providers/papi/templates/property.tmpl
+++ b/pkg/providers/papi/templates/property.tmpl
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/templates/rules_module.tmpl
+++ b/pkg/providers/papi/templates/rules_module.tmpl
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/templates/rules_v2025-07-07.tmpl
+++ b/pkg/providers/papi/templates/rules_v2025-07-07.tmpl
@@ -9008,11 +9008,14 @@ visitor_prioritization_queue_it {
 {{- if and (eq $k "customerId") (ne $v nil)}}
         customer_id = {{template "Text" $v}}
 {{- end}}
-{{- if and (eq $k "secretKey") (ne $v nil)}}
-        secret_key = {{template "Text" $v}}
+{{- if and (eq $k "apiKeyCamGuid") (ne $v nil)}}
+        api_key_cam_guid = {{template "Text" $v}}
 {{- end}}
-{{- if and (eq $k "apiKey") (ne $v nil)}}
-        api_key = {{template "Text" $v}}
+{{- if and (eq $k "additionalHeadersMode") (ne $v nil)}}
+        additional_headers_mode = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "additionalHeadersList"}}
+		additional_headers_list = [{{range $v}}"{{. | Escape}}", {{end}}]
 {{- end}}
 {{- end}}
 }

--- a/pkg/providers/papi/templates/rules_v2025-09-09.tmpl
+++ b/pkg/providers/papi/templates/rules_v2025-09-09.tmpl
@@ -9095,11 +9095,14 @@ visitor_prioritization_queue_it {
 {{- if and (eq $k "customerId") (ne $v nil)}}
         customer_id = {{template "Text" $v}}
 {{- end}}
-{{- if and (eq $k "secretKey") (ne $v nil)}}
-        secret_key = {{template "Text" $v}}
+{{- if and (eq $k "apiKeyCamGuid") (ne $v nil)}}
+        api_key_cam_guid = {{template "Text" $v}}
 {{- end}}
-{{- if and (eq $k "apiKey") (ne $v nil)}}
-        api_key = {{template "Text" $v}}
+{{- if and (eq $k "additionalHeadersMode") (ne $v nil)}}
+        additional_headers_mode = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "additionalHeadersList"}}
+		additional_headers_list = [{{range $v}}"{{. | Escape}}", {{end}}]
 {{- end}}
 {{- end}}
 }

--- a/pkg/providers/papi/templates/rules_v2025-10-16.tmpl
+++ b/pkg/providers/papi/templates/rules_v2025-10-16.tmpl
@@ -9156,11 +9156,14 @@ visitor_prioritization_queue_it {
 {{- if and (eq $k "customerId") (ne $v nil)}}
         customer_id = {{template "Text" $v}}
 {{- end}}
-{{- if and (eq $k "secretKey") (ne $v nil)}}
-        secret_key = {{template "Text" $v}}
+{{- if and (eq $k "apiKeyCamGuid") (ne $v nil)}}
+        api_key_cam_guid = {{template "Text" $v}}
 {{- end}}
-{{- if and (eq $k "apiKey") (ne $v nil)}}
-        api_key = {{template "Text" $v}}
+{{- if and (eq $k "additionalHeadersMode") (ne $v nil)}}
+        additional_headers_mode = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "additionalHeadersList"}}
+		additional_headers_list = [{{range $v}}"{{. | Escape}}", {{end}}]
 {{- end}}
 {{- end}}
 }

--- a/pkg/providers/papi/templates/rules_v2026-01-09.tmpl
+++ b/pkg/providers/papi/templates/rules_v2026-01-09.tmpl
@@ -162,7 +162,9 @@
 	{{- else if eq .Name "firstPartyMarketingPlus"}}{{- template "firstPartyMarketingPlus" .}}
 	{{- else if eq .Name "forwardRewrite"}}{{- template "forwardRewrite" .}}
 	{{- else if eq .Name "g2oheader"}}{{- template "g2oheader" .}}
+	{{- else if eq .Name "gRPC"}}{{- template "gRPC" .}}
 	{{- else if eq .Name "globalRequestNumber"}}{{- template "globalRequestNumber" .}}
+	{{- else if eq .Name "googleTagGateway"}}{{- template "googleTagGateway" .}}
 	{{- else if eq .Name "govCloud"}}{{- template "govCloud" .}}
 	{{- else if eq .Name "graphqlCaching"}}{{- template "graphqlCaching" .}}
 	{{- else if eq .Name "gzipResponse"}}{{- template "gzipResponse" .}}
@@ -183,6 +185,7 @@
 	{{- else if eq .Name "largeFileOptimization"}}{{- template "largeFileOptimization" .}}
 	{{- else if eq .Name "largeFileOptimizationAdvanced"}}{{- template "largeFileOptimizationAdvanced" .}}
 	{{- else if eq .Name "limitBitRate"}}{{- template "limitBitRate" .}}
+	{{- else if eq .Name "localhostLoopbackProtection"}}{{- template "localhostLoopbackProtection" .}}
 	{{- else if eq .Name "logCustom"}}{{- template "logCustom" .}}
 	{{- else if eq .Name "mPulse"}}{{- template "mPulse" .}}
 	{{- else if eq .Name "manifestPersonalization"}}{{- template "manifestPersonalization" .}}
@@ -201,6 +204,7 @@
 	{{- else if eq .Name "modifyOutgoingResponseHeader"}}{{- template "modifyOutgoingResponseHeader" .}}
 	{{- else if eq .Name "modifyViaHeader"}}{{- template "modifyViaHeader" .}}
 	{{- else if eq .Name "mtlsOriginKeystore"}}{{- template "mtlsOriginKeystore" .}}
+	{{- else if eq .Name "optimizeTextStreaming"}}{{- template "optimizeTextStreaming" .}}
 	{{- else if eq .Name "origin"}}{{- template "origin" .}}
 	{{- else if eq .Name "originCharacteristics"}}{{- template "originCharacteristics" .}}
 	{{- else if eq .Name "originCharacteristicsWsd"}}{{- template "originCharacteristicsWsd" .}}
@@ -212,6 +216,7 @@
 	{{- else if eq .Name "persistentConnection"}}{{- template "persistentConnection" .}}
 	{{- else if eq .Name "personallyIdentifiableInformation"}}{{- template "personallyIdentifiableInformation" .}}
 	{{- else if eq .Name "phasedRelease"}}{{- template "phasedRelease" .}}
+	{{- else if eq .Name "pqcClientToEdge"}}{{- template "pqcClientToEdge" .}}
 	{{- else if eq .Name "pqcOrigin"}}{{- template "pqcOrigin" .}}
 	{{- else if eq .Name "preconnect"}}{{- template "preconnect" .}}
 	{{- else if eq .Name "predictiveContentDelivery"}}{{- template "predictiveContentDelivery" .}}
@@ -272,6 +277,7 @@
 	{{- else if eq .Name "verifyJsonWebToken"}}{{- template "verifyJsonWebToken" .}}
 	{{- else if eq .Name "verifyJsonWebTokenForDcp"}}{{- template "verifyJsonWebTokenForDcp" .}}
 	{{- else if eq .Name "verifyTokenAuthorization"}}{{- template "verifyTokenAuthorization" .}}
+	{{- else if eq .Name "videoManagerCloudinary"}}{{- template "videoManagerCloudinary" .}}
 	{{- else if eq .Name "virtualWaitingRoom"}}{{- template "virtualWaitingRoom" .}}
 	{{- else if eq .Name "virtualWaitingRoomWithEdgeWorkers"}}{{- template "virtualWaitingRoomWithEdgeWorkers" .}}
 	{{- else if eq .Name "visitorPrioritization"}}{{- template "visitorPrioritization" .}}
@@ -2094,6 +2100,15 @@ content_targeting_protection {
 {{- if and (eq $k "referrerRedirectUrl") (ne $v nil)}}
         referrer_redirect_url = {{template "Text" $v}}
 {{- end}}
+{{- if and (eq $k "advancedSupportTitle") (ne $v nil)}}
+        advanced_support_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "geoProtectionXffMode") (ne $v nil)}}
+        geo_protection_xff_mode = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "ipProtectionXffMode") (ne $v nil)}}
+        ip_protection_xff_mode = {{template "Text" $v}}
+{{- end}}
 {{- end}}
 }
 {{- end}}
@@ -2153,6 +2168,9 @@ cp_code {
 {{- end}}
 {{- $v := .Options}}
 {{- range $k, $v := $v}}
+{{- if and (eq $k "enableDefaultContentProviderCode") (ne $v nil)}}
+		enable_default_content_provider_code = {{$v}}
+{{- end}}
 {{- if eq $k "value" }}
 		{{- if $v}}
 		value {
@@ -3227,6 +3245,18 @@ edge_worker {
 {{- if and (eq $k "resourceTier") (ne $v nil)}}
         resource_tier = {{template "Text" $v}}
 {{- end}}
+{{- if and (eq $k "failOpenTitle") (ne $v nil)}}
+        fail_open_title = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "continueOnError") (ne $v nil)}}
+		continue_on_error = {{$v}}
+{{- end}}
+{{- if and (eq $k "continueOnErrorDisclaimer") (ne $v nil)}}
+        continue_on_error_disclaimer = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "mPulseTitle") (ne $v nil)}}
+        m_pulse_title = {{template "Text" $v}}
+{{- end}}
 {{- if and (eq $k "mPulse") (ne $v nil)}}
 		m_pulse = {{$v}}
 {{- end}}
@@ -3846,6 +3876,28 @@ g2oheader {
 {{- end}}
 }
 {{- end}}
+{{- define "gRPC"}}
+g_rpc {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "enableBidirectionalStreaming") (ne $v nil)}}
+		enable_bidirectional_streaming = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
 {{- define "globalRequestNumber"}}
 global_request_number {
 {{- if .UUID}}
@@ -3867,6 +3919,43 @@ global_request_number {
 {{- end}}
 {{- if and (eq $k "variableName") (ne $v nil)}}
         variable_name = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
+{{- define "googleTagGateway"}}
+google_tag_gateway {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "googleTagId") (ne $v nil)}}
+        google_tag_id = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "servingPath") (ne $v nil)}}
+        serving_path = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "advancedOption") (ne $v nil)}}
+		advanced_option = {{$v}}
+{{- end}}
+{{- if and (eq $k "trueClientIpHeader") (ne $v nil)}}
+		true_client_ip_header = {{$v}}
+{{- end}}
+{{- if and (eq $k "scriptInjection") (ne $v nil)}}
+		script_injection = {{$v}}
+{{- end}}
+{{- if and (eq $k "setupTag") (ne $v nil)}}
+		setup_tag = {{$v}}
 {{- end}}
 {{- end}}
 }
@@ -3986,6 +4075,12 @@ health_detection {
 {{- end}}
 {{- if and (eq $k "maximumReconnects") (ne $v nil)}}
 		maximum_reconnects = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "errorOnFirstByteTimeout") (ne $v nil)}}
+		error_on_first_byte_timeout = {{$v}}
+{{- end}}
+{{- if eq $k "httpErrorCodes"}}
+		http_error_codes = [{{range $v}}"{{. | Escape}}", {{end}}]
 {{- end}}
 {{- end}}
 }
@@ -4735,6 +4830,28 @@ limit_bit_rate {
 {{- end}}
 }
 {{- end}}
+{{- define "localhostLoopbackProtection"}}
+localhost_loopback_protection {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "loopbackCrossAccountPolicy") (ne $v nil)}}
+		loopback_cross_account_policy = {{$v}}
+{{- end}}
+{{- if eq $k "vcdIds"}}
+		vcd_ids = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- end}}
+}
+{{- end}}
 {{- define "logCustom"}}
 log_custom {
 {{- if .UUID}}
@@ -5413,6 +5530,25 @@ mtls_origin_keystore {
 {{- end}}
 }
 {{- end}}
+{{- define "optimizeTextStreaming"}}
+optimize_text_streaming {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
 {{- define "origin"}}
 origin {
 {{- if .UUID}}
@@ -5428,6 +5564,9 @@ origin {
 {{- range $k, $v := $v}}
 {{- if and (eq $k "originType") (ne $v nil)}}
         origin_type = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "aosHostname") (ne $v nil)}}
+        aos_hostname = {{template "Text" $v}}
 {{- end}}
 {{- if eq $k "netStorage" }}
 		{{- if $v}}
@@ -6242,6 +6381,15 @@ origin_characteristics {
 {{- if and (eq $k "endPointService") (ne $v nil)}}
         end_point_service = {{template "Text" $v}}
 {{- end}}
+{{- if and (eq $k "aosHmacKeyAccessId") (ne $v nil)}}
+        aos_hmac_key_access_id = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "aosHmacKeySecret") (ne $v nil)}}
+        aos_hmac_key_secret = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "aosAccessKeyVersionGuid") (ne $v nil)}}
+        aos_access_key_version_guid = {{template "Text" $v}}
+{{- end}}
 {{- if and (eq $k "sortQueryParams") (ne $v nil)}}
 		sort_query_params = {{$v}}
 {{- end}}
@@ -6589,6 +6737,25 @@ phased_release {
 {{- end}}
 }
 {{- end}}
+{{- define "pqcClientToEdge"}}
+pqc_client_to_edge {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
 {{- define "pqcOrigin"}}
 pqc_origin {
 {{- if .UUID}}
@@ -6604,6 +6771,9 @@ pqc_origin {
 {{- range $k, $v := $v}}
 {{- if and (eq $k "enabled") (ne $v nil)}}
 		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "pqcClientHelloKeys") (ne $v nil)}}
+		pqc_client_hello_keys = {{$v}}
 {{- end}}
 {{- end}}
 }
@@ -8632,6 +8802,77 @@ verify_token_authorization {
 {{- end}}
 }
 {{- end}}
+{{- define "videoManagerCloudinary"}}
+video_manager_cloudinary {
+{{- if .UUID}}
+	uuid = "{{.UUID}}"
+{{- end}}
+{{- if .TemplateUuid}}
+	template_uuid = "{{.TemplateUuid}}"
+{{- end}}
+{{- if .Locked}}
+	locked = {{.Locked}}
+{{- end}}
+{{- $v := .Options}}
+{{- range $k, $v := $v}}
+{{- if and (eq $k "enabled") (ne $v nil)}}
+		enabled = {{$v}}
+{{- end}}
+{{- if and (eq $k "avmAccessKeyVersionGuid") (ne $v nil)}}
+        avm_access_key_version_guid = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "cpCodeCloudinary" }}
+		{{- if $v}}
+		cp_code_cloudinary {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "id") (ne $v nil)}}
+		id = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "name") (ne $v nil)}}
+        name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "createdDate") (ne $v nil)}}
+		created_date = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "description") (ne $v nil)}}
+        description = {{template "Text" $v}}
+{{- end}}
+{{- if eq $k "products"}}
+		products = [{{range $v}}"{{. | Escape}}", {{end}}]
+{{- end}}
+{{- if eq $k "cpCodeLimits" }}
+		{{- if $v}}
+		cp_code_limits {
+{{- range $k, $v := $v}}
+{{- if and (eq $k "currentCapacity") (ne $v nil)}}
+		current_capacity = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "limit") (ne $v nil)}}
+		limit = {{$v | AsInt}}
+{{- end}}
+{{- if and (eq $k "limitType") (ne $v nil)}}
+        limit_type = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- end}}
+		}
+		{{- end}}
+{{- end}}
+{{- if and (eq $k "rewriteUrl") (ne $v nil)}}
+		rewrite_url = {{$v}}
+{{- end}}
+{{- if and (eq $k "cloudName") (ne $v nil)}}
+        cloud_name = {{template "Text" $v}}
+{{- end}}
+{{- if and (eq $k "transformations") (ne $v nil)}}
+        transformations = {{template "Text" $v}}
+{{- end}}
+{{- end}}
+}
+{{- end}}
 {{- define "virtualWaitingRoom"}}
 virtual_waiting_room {
 {{- if .UUID}}
@@ -10363,7 +10604,7 @@ data "akamai_property_rules_builder" "{{$r.TerraformName}}" {
 	{{- $children := $r.Children}}
 	{{- $isRoot := $r.IsRoot}}
 	{{- with $r.Rule}}
-	rules_v2025_05_30 {
+	rules_v2026_01_09 {
         name = "{{.Name | Escape}}"
 		{{- if $isRoot}}
         is_secure = {{.Options.IsSecure}}

--- a/pkg/providers/papi/testdata/basic-bootstrap/property.tf
+++ b/pkg/providers/papi/testdata/basic-bootstrap/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic-ccm-hostnames-with-mtls/property.tf
+++ b/pkg/providers/papi/testdata/basic-ccm-hostnames-with-mtls/property.tf
@@ -34,8 +34,8 @@ resource "akamai_property" "test-edgesuite-net" {
     cname_to               = "foo"
     cert_provisioning_type = "CCM"
     ccm_certificates {
-      rsa_cert_id    = "123456"
-      ecdasa_cert_id = "343434"
+      rsa_cert_id   = "123456"
+      ecdsa_cert_id = "343434"
     }
     mtls {
       ca_set_id          = "551438"

--- a/pkg/providers/papi/testdata/basic-ccm-hostnames-with-mtls/property.tf
+++ b/pkg/providers/papi/testdata/basic-ccm-hostnames-with-mtls/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic-ccm-hostnames-without-disallowed_tls_versions-in-tls_configuration/property.tf
+++ b/pkg/providers/papi/testdata/basic-ccm-hostnames-without-disallowed_tls_versions-in-tls_configuration/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic-ccm-hostnames-without-disallowed_tls_versions-in-tls_configuration/property.tf
+++ b/pkg/providers/papi/testdata/basic-ccm-hostnames-without-disallowed_tls_versions-in-tls_configuration/property.tf
@@ -34,8 +34,8 @@ resource "akamai_property" "test-edgesuite-net" {
     cname_to               = "foo"
     cert_provisioning_type = "CCM"
     ccm_certificates {
-      rsa_cert_id    = "123456"
-      ecdasa_cert_id = "343434"
+      rsa_cert_id   = "123456"
+      ecdsa_cert_id = "343434"
     }
     tls_configuration {
       cipher_profile              = "ak-tls-1-3"

--- a/pkg/providers/papi/testdata/basic-ccm-hostnames/property.tf
+++ b/pkg/providers/papi/testdata/basic-ccm-hostnames/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic-ccm-hostnames/property.tf
+++ b/pkg/providers/papi/testdata/basic-ccm-hostnames/property.tf
@@ -34,8 +34,8 @@ resource "akamai_property" "test-edgesuite-net" {
     cname_to               = "foo"
     cert_provisioning_type = "CCM"
     ccm_certificates {
-      rsa_cert_id    = "123456"
-      ecdasa_cert_id = "343434"
+      rsa_cert_id   = "123456"
+      ecdsa_cert_id = "343434"
     }
   }
   hostnames {

--- a/pkg/providers/papi/testdata/basic-non-default-ttl/property.tf
+++ b/pkg/providers/papi/testdata/basic-non-default-ttl/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic-v1/property.tf
+++ b/pkg/providers/papi/testdata/basic-v1/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic/property.tf
+++ b/pkg/providers/papi/testdata/basic/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic_not_latest/property.tf
+++ b/pkg/providers/papi/testdata/basic_not_latest/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic_property_with_empty_hostname_id/property.tf
+++ b/pkg/providers/papi/testdata/basic_property_with_empty_hostname_id/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic_with_activation_note/property.tf
+++ b/pkg/providers/papi/testdata/basic_with_activation_note/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic_with_both_activations/property.tf
+++ b/pkg/providers/papi/testdata/basic_with_both_activations/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic_with_cert_provisioning_type/property.tf
+++ b/pkg/providers/papi/testdata/basic_with_cert_provisioning_type/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic_with_multiline_activation_note/property.tf
+++ b/pkg/providers/papi/testdata/basic_with_multiline_activation_note/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic_with_production_activation/property.tf
+++ b/pkg/providers/papi/testdata/basic_with_production_activation/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic_with_use_cases/property.tf
+++ b/pkg/providers/papi/testdata/basic_with_use_cases/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/basic_without_activation/property.tf
+++ b/pkg/providers/papi/testdata/basic_without_activation/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/enhancement-tls/property.tf
+++ b/pkg/providers/papi/testdata/enhancement-tls/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/hostname-bucket/bootstrap/no-hostnames/property.tf
+++ b/pkg/providers/papi/testdata/hostname-bucket/bootstrap/no-hostnames/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/hostname-bucket/bootstrap/production-no-hostnames/property.tf
+++ b/pkg/providers/papi/testdata/hostname-bucket/bootstrap/production-no-hostnames/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/hostname-bucket/bootstrap/staging-production/property.tf
+++ b/pkg/providers/papi/testdata/hostname-bucket/bootstrap/staging-production/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/hostname-bucket/no-hostnames/property.tf
+++ b/pkg/providers/papi/testdata/hostname-bucket/no-hostnames/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/hostname-bucket/production-staging-no-hostnames/property.tf
+++ b/pkg/providers/papi/testdata/hostname-bucket/production-staging-no-hostnames/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/hostname-bucket/production/property.tf
+++ b/pkg/providers/papi/testdata/hostname-bucket/production/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/hostname-bucket/staging-production-diff-cert-provisioning-type/property.tf
+++ b/pkg/providers/papi/testdata/hostname-bucket/staging-production-diff-cert-provisioning-type/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/hostname-bucket/staging-production-diff-edge-hostname/property.tf
+++ b/pkg/providers/papi/testdata/hostname-bucket/staging-production-diff-edge-hostname/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/hostname-bucket/staging-production-diff/property.tf
+++ b/pkg/providers/papi/testdata/hostname-bucket/staging-production-diff/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/hostname-bucket/staging-production/property.tf
+++ b/pkg/providers/papi/testdata/hostname-bucket/staging-production/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/hostname-bucket/staging/property.tf
+++ b/pkg/providers/papi/testdata/hostname-bucket/staging/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/include_basic/includes.tf
+++ b/pkg/providers/papi/testdata/include_basic/includes.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/include_basic_multiline_notes/includes.tf
+++ b/pkg/providers/papi/testdata/include_basic_multiline_notes/includes.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/include_basic_rules_as_hcl/includes.tf
+++ b/pkg/providers/papi/testdata/include_basic_rules_as_hcl/includes.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/include_multitarget/includes.tf
+++ b/pkg/providers/papi/testdata/include_multitarget/includes.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/include_multitarget/module_config.tf
+++ b/pkg/providers/papi/testdata/include_multitarget/module_config.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/include_no_network/includes.tf
+++ b/pkg/providers/papi/testdata/include_no_network/includes.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/include_single_network/includes.tf
+++ b/pkg/providers/papi/testdata/include_single_network/includes.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/multitarget-property/module_config.tf
+++ b/pkg/providers/papi/testdata/multitarget-property/module_config.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/multitarget-property/property.tf
+++ b/pkg/providers/papi/testdata/multitarget-property/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/ruleformats/basic-rules-datasource-empty-options/property.tf
+++ b/pkg/providers/papi/testdata/ruleformats/basic-rules-datasource-empty-options/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/ruleformats/basic-rules-datasource-serial/property.tf
+++ b/pkg/providers/papi/testdata/ruleformats/basic-rules-datasource-serial/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/ruleformats/basic-rules-datasource/property.tf
+++ b/pkg/providers/papi/testdata/ruleformats/basic-rules-datasource/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/ruleformats/rules-with-rdn-details-datasource/property.tf
+++ b/pkg/providers/papi/testdata/ruleformats/rules-with-rdn-details-datasource/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/ruleformats/v2023_01_05/rules_datasource/property.tf
+++ b/pkg/providers/papi/testdata/ruleformats/v2023_01_05/rules_datasource/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/ruleformats/v2023_05_30/rules_datasource/property.tf
+++ b/pkg/providers/papi/testdata/ruleformats/v2023_05_30/rules_datasource/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/ruleformats/v2023_09_20/rules_datasource/property.tf
+++ b/pkg/providers/papi/testdata/ruleformats/v2023_09_20/rules_datasource/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/ruleformats/v2023_10_30/rules_datasource/property.tf
+++ b/pkg/providers/papi/testdata/ruleformats/v2023_10_30/rules_datasource/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/ruleformats/v2024_01_09/rules_datasource/property.tf
+++ b/pkg/providers/papi/testdata/ruleformats/v2024_01_09/rules_datasource/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/ruleformats/v2024_02_12/rules_datasource/property.tf
+++ b/pkg/providers/papi/testdata/ruleformats/v2024_02_12/rules_datasource/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/ruleformats/v2024_05_31/rules_datasource/property.tf
+++ b/pkg/providers/papi/testdata/ruleformats/v2024_05_31/rules_datasource/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/ruleformats/v2024_08_13/rules_datasource/property.tf
+++ b/pkg/providers/papi/testdata/ruleformats/v2024_08_13/rules_datasource/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/ruleformats/v2024_10_21/rules_datasource/property.tf
+++ b/pkg/providers/papi/testdata/ruleformats/v2024_10_21/rules_datasource/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/ruleformats/v2025_01_13/rules_datasource/property.tf
+++ b/pkg/providers/papi/testdata/ruleformats/v2025_01_13/rules_datasource/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/ruleformats/v2025_02_18/rules_datasource/property.tf
+++ b/pkg/providers/papi/testdata/ruleformats/v2025_02_18/rules_datasource/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/ruleformats/v2025_03_24/rules_datasource/property.tf
+++ b/pkg/providers/papi/testdata/ruleformats/v2025_03_24/rules_datasource/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/ruleformats/v2025_04_29/rules_datasource/property.tf
+++ b/pkg/providers/papi/testdata/ruleformats/v2025_04_29/rules_datasource/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/ruleformats/v2025_05_30/rules_datasource/property.tf
+++ b/pkg/providers/papi/testdata/ruleformats/v2025_05_30/rules_datasource/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/ruleformats/v2025_07_07/rules_datasource/property.tf
+++ b/pkg/providers/papi/testdata/ruleformats/v2025_07_07/rules_datasource/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/ruleformats/v2025_09_09/rules_datasource/property.tf
+++ b/pkg/providers/papi/testdata/ruleformats/v2025_09_09/rules_datasource/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/ruleformats/v2025_10_16/rules_datasource/property.tf
+++ b/pkg/providers/papi/testdata/ruleformats/v2025_10_16/rules_datasource/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/ruleformats/v2026_01_09/rules_datasource/import.sh
+++ b/pkg/providers/papi/testdata/ruleformats/v2026_01_09/rules_datasource/import.sh
@@ -1,0 +1,2 @@
+terraform init
+terraform import akamai_property.test-edgesuite-net prp_12345,test_contract,grp_12345,LATEST

--- a/pkg/providers/papi/testdata/ruleformats/v2026_01_09/rules_datasource/mock_rules.json
+++ b/pkg/providers/papi/testdata/ruleformats/v2026_01_09/rules_datasource/mock_rules.json
@@ -1,0 +1,35 @@
+{
+  "accountId": "test_account",
+  "contractId": "test_contract",
+  "groupId": "grp_12345",
+  "propertyId": "prp_12345",
+  "propertyVersion": 5,
+  "etag": "4607f363da8bc05b0c0f0f7524985d2fbc5d864d",
+  "ruleFormat": "v2026-01-09",
+  "rules": {
+    "behaviors": [
+      {
+        "name": "datastream",
+        "options": {
+          "beaconStreamTitle": "test",
+          "collectMidgressTraffic": false,
+          "datastreamIds": "77-85-6",
+          "enabled": true,
+          "logEnabled": false,
+          "logStreamName": [
+            "60"
+          ],
+          "logStreamTitle": "test",
+          "samplingPercentage": 100,
+          "streamType": "LOG"
+        }
+      }
+    ],
+    "children": [],
+    "name": "default",
+    "options": {},
+    "variables": [],
+    "uuid": "default",
+    "criteriaMustSatisfy": "all"
+  }
+}

--- a/pkg/providers/papi/testdata/ruleformats/v2026_01_09/rules_datasource/property.tf
+++ b/pkg/providers/papi/testdata/ruleformats/v2026_01_09/rules_datasource/property.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = ">= 9.3.0"
+      version = ">= 10.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/pkg/providers/papi/testdata/ruleformats/v2026_01_09/rules_datasource/property.tf
+++ b/pkg/providers/papi/testdata/ruleformats/v2026_01_09/rules_datasource/property.tf
@@ -1,0 +1,41 @@
+terraform {
+  required_providers {
+    akamai = {
+      source  = "akamai/akamai"
+      version = ">= 9.3.0"
+    }
+  }
+  required_version = ">= 1.0"
+}
+
+provider "akamai" {
+  edgerc         = var.edgerc_path
+  config_section = var.config_section
+}
+
+resource "akamai_property" "test-edgesuite-net" {
+  name        = "test.edgesuite.net"
+  contract_id = var.contract_id
+  group_id    = var.group_id
+  product_id  = "prd_HTTP_Content_Del"
+  rule_format = data.akamai_property_rules_builder.test-edgesuite-net_rule_default.rule_format
+  rules       = data.akamai_property_rules_builder.test-edgesuite-net_rule_default.json
+}
+
+# NOTE: Be careful when removing this resource as you can disable traffic
+#resource "akamai_property_activation" "test-edgesuite-net-staging" {
+#  property_id                    = akamai_property.test-edgesuite-net.id
+#  contact                        = []
+#  version                        = var.activate_latest_on_staging ? akamai_property.test-edgesuite-net.latest_version : akamai_property.test-edgesuite-net.staging_version
+#  network                        = "STAGING"
+#  auto_acknowledge_rule_warnings = false
+#}
+
+# NOTE: Be careful when removing this resource as you can disable traffic
+#resource "akamai_property_activation" "test-edgesuite-net-production" {
+#  property_id                    = akamai_property.test-edgesuite-net.id
+#  contact                        = []
+#  version                        = var.activate_latest_on_production ? akamai_property.test-edgesuite-net.latest_version : akamai_property.test-edgesuite-net.production_version
+#  network                        = "PRODUCTION"
+#  auto_acknowledge_rule_warnings = false
+#}

--- a/pkg/providers/papi/testdata/ruleformats/v2026_01_09/rules_datasource/rules.tf
+++ b/pkg/providers/papi/testdata/ruleformats/v2026_01_09/rules_datasource/rules.tf
@@ -1,0 +1,21 @@
+
+data "akamai_property_rules_builder" "test-edgesuite-net_rule_default" {
+  rules_v2026_01_09 {
+    name      = "default"
+    is_secure = false
+    uuid      = "default"
+    behavior {
+      datastream {
+        beacon_stream_title      = "test"
+        collect_midgress_traffic = false
+        datastream_ids           = "77-85-6"
+        enabled                  = true
+        log_enabled              = false
+        log_stream_name          = ["60", ]
+        log_stream_title         = "test"
+        sampling_percentage      = 100
+        stream_type              = "LOG"
+      }
+    }
+  }
+}

--- a/pkg/providers/papi/testdata/ruleformats/v2026_01_09/rules_datasource/variables.tf
+++ b/pkg/providers/papi/testdata/ruleformats/v2026_01_09/rules_datasource/variables.tf
@@ -1,0 +1,29 @@
+variable "edgerc_path" {
+  type    = string
+  default = "~/.edgerc"
+}
+
+variable "config_section" {
+  type    = string
+  default = "test_section"
+}
+
+variable "contract_id" {
+  type    = string
+  default = "test_contract"
+}
+
+variable "group_id" {
+  type    = string
+  default = "grp_12345"
+}
+
+#variable "activate_latest_on_staging" {
+#  type    = bool
+#  default = true
+#}
+
+#variable "activate_latest_on_production" {
+#  type    = bool
+#  default = true
+#}


### PR DESCRIPTION
## 2.8.0 (Feb 25, 2026)

### FEATURES/ENHANCEMENTS:

* ClientLists
  * Removed `version` from the `akamai_clientlist_activation` template because the `version` attribute is marked now in the schema as `Computed` instead of `Required`.

* Cloud Certificates (Beta)
  * Added the `lifecycle { create_before_destroy = true }` block to the `akamai_cloudcertificates_certificate` resource template.

* PAPI
  * Added support for the new rule format `v2026-01-09`.
  * Removed the `secret_key` and `api_key` attributes and introduced support for the `api_key_cam_guid`, `additional_headers_mode`, and `additional_headers_list` attributes 
    in the `visitor_prioritization_queue_it` behavior when working with rules in JSON or the `akamai_property_rules_builder` data source using these rule formats: `v2025-05-30`, `v2025-07-07`, `v2025-09-09`, and `v2025-10-16`.

### BUG FIXES:

* PAPI
  * Fixed a typo in the exported `ccm_certificates` block for the `akamai_property` resource: renamed `ecdasa_cert_id` to `ecdsa_cert_id` to match the provider schema.