### PR TITLE
DXE-6925 export multi_provider_dnssec in akamai_dns_zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # RELEASE NOTES
 
+## Unreleased
+
+### FEATURES/ENHANCEMENTS:
+
+* DNS
+  * Added `multi_provider_dnssec` to the generated `akamai_dns_zone` resource when exporting a zone, to match the same field added to the Terraform provider.
+
 ## 2.11.0 (Jul 1, 2026)
 
 ### FEATURES/ENHANCEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### FEATURES/ENHANCEMENTS:
 
 * DNS
-  * Added `multi_provider_dnssec` to the generated `akamai_dns_zone` resource when exporting a zone, to match the same field added to the Terraform provider.
+  * Added export of the field `multi_provider_dnssec` to the `akamai_dns_zone`.
 
 ## 2.11.0 (Jul 1, 2026)
 

--- a/pkg/providers/dns/template_processing.go
+++ b/pkg/providers/dns/template_processing.go
@@ -31,6 +31,7 @@ type (
 		Comment               string
 		SignAndServe          bool
 		SignAndServeAlgorithm string
+		MultiProviderDNSSEC   bool
 		OutboundZoneTransfer  *dns.OutboundZoneTransfer
 		TSIGKey               *dns.TSIGKey
 		Target                string

--- a/pkg/providers/dns/templates/definitions.tmpl
+++ b/pkg/providers/dns/templates/definitions.tmpl
@@ -31,6 +31,7 @@ resource "akamai_dns_zone" "{{.BlockName}}" {
     comment = {{template "Text" .Comment}}
     sign_and_serve = {{.SignAndServe}}
     sign_and_serve_algorithm = "{{.SignAndServeAlgorithm}}"
+    multi_provider_dnssec = {{.MultiProviderDNSSEC}}
     {{- with .OutboundZoneTransfer}}
     outbound_zone_transfer {
         acl = [{{range $i, $v := .ACL}}{{if $i}}, {{end}}"{{$v}}"{{end}}]

--- a/pkg/providers/dns/testdata/end_to_end/create_zone_configonly/example_com.tf
+++ b/pkg/providers/dns/testdata/end_to_end/create_zone_configonly/example_com.tf
@@ -26,6 +26,7 @@ resource "akamai_dns_zone" "example_com" {
   comment                  = ""
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
+  multi_provider_dnssec = false
   target                   = ""
   end_customer_id          = ""
 }

--- a/pkg/providers/dns/testdata/end_to_end/create_zone_configonly/example_com.tf
+++ b/pkg/providers/dns/testdata/end_to_end/create_zone_configonly/example_com.tf
@@ -26,7 +26,7 @@ resource "akamai_dns_zone" "example_com" {
   comment                  = ""
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
-  multi_provider_dnssec = false
+  multi_provider_dnssec    = false
   target                   = ""
   end_customer_id          = ""
 }

--- a/pkg/providers/dns/testdata/end_to_end/create_zone_createconfig_from_file/example_com.tf
+++ b/pkg/providers/dns/testdata/end_to_end/create_zone_createconfig_from_file/example_com.tf
@@ -26,6 +26,7 @@ resource "akamai_dns_zone" "example_com" {
   comment                  = ""
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
+  multi_provider_dnssec = false
   target                   = ""
   end_customer_id          = ""
 }

--- a/pkg/providers/dns/testdata/end_to_end/create_zone_createconfig_from_file/example_com.tf
+++ b/pkg/providers/dns/testdata/end_to_end/create_zone_createconfig_from_file/example_com.tf
@@ -26,7 +26,7 @@ resource "akamai_dns_zone" "example_com" {
   comment                  = ""
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
-  multi_provider_dnssec = false
+  multi_provider_dnssec    = false
   target                   = ""
   end_customer_id          = ""
 }

--- a/pkg/providers/dns/testdata/end_to_end/create_zone_multiple_recordnames/example_com.tf
+++ b/pkg/providers/dns/testdata/end_to_end/create_zone_multiple_recordnames/example_com.tf
@@ -26,6 +26,7 @@ resource "akamai_dns_zone" "example_com" {
   comment                  = ""
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
+  multi_provider_dnssec = false
   target                   = ""
   end_customer_id          = ""
 }

--- a/pkg/providers/dns/testdata/end_to_end/create_zone_multiple_recordnames/example_com.tf
+++ b/pkg/providers/dns/testdata/end_to_end/create_zone_multiple_recordnames/example_com.tf
@@ -26,7 +26,7 @@ resource "akamai_dns_zone" "example_com" {
   comment                  = ""
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
-  multi_provider_dnssec = false
+  multi_provider_dnssec    = false
   target                   = ""
   end_customer_id          = ""
 }

--- a/pkg/providers/dns/testdata/end_to_end/create_zone_namesonly_and_config/example_com.tf
+++ b/pkg/providers/dns/testdata/end_to_end/create_zone_namesonly_and_config/example_com.tf
@@ -26,6 +26,7 @@ resource "akamai_dns_zone" "example_com" {
   comment                  = ""
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
+  multi_provider_dnssec = false
   target                   = ""
   end_customer_id          = ""
 }

--- a/pkg/providers/dns/testdata/end_to_end/create_zone_namesonly_and_config/example_com.tf
+++ b/pkg/providers/dns/testdata/end_to_end/create_zone_namesonly_and_config/example_com.tf
@@ -26,7 +26,7 @@ resource "akamai_dns_zone" "example_com" {
   comment                  = ""
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
-  multi_provider_dnssec = false
+  multi_provider_dnssec    = false
   target                   = ""
   end_customer_id          = ""
 }

--- a/pkg/providers/dns/testdata/end_to_end/create_zone_paginated_recordsets/example_com.tf
+++ b/pkg/providers/dns/testdata/end_to_end/create_zone_paginated_recordsets/example_com.tf
@@ -26,6 +26,7 @@ resource "akamai_dns_zone" "example_com" {
   comment                  = ""
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
+  multi_provider_dnssec = false
   target                   = ""
   end_customer_id          = ""
 }

--- a/pkg/providers/dns/testdata/end_to_end/create_zone_paginated_recordsets/example_com.tf
+++ b/pkg/providers/dns/testdata/end_to_end/create_zone_paginated_recordsets/example_com.tf
@@ -26,7 +26,7 @@ resource "akamai_dns_zone" "example_com" {
   comment                  = ""
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
-  multi_provider_dnssec = false
+  multi_provider_dnssec    = false
   target                   = ""
   end_customer_id          = ""
 }

--- a/pkg/providers/dns/testdata/end_to_end/create_zone_recordname_and_configonly/example_com.tf
+++ b/pkg/providers/dns/testdata/end_to_end/create_zone_recordname_and_configonly/example_com.tf
@@ -26,6 +26,7 @@ resource "akamai_dns_zone" "example_com" {
   comment                  = ""
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
+  multi_provider_dnssec = false
   target                   = ""
   end_customer_id          = ""
 }

--- a/pkg/providers/dns/testdata/end_to_end/create_zone_recordname_and_configonly/example_com.tf
+++ b/pkg/providers/dns/testdata/end_to_end/create_zone_recordname_and_configonly/example_com.tf
@@ -26,7 +26,7 @@ resource "akamai_dns_zone" "example_com" {
   comment                  = ""
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
-  multi_provider_dnssec = false
+  multi_provider_dnssec    = false
   target                   = ""
   end_customer_id          = ""
 }

--- a/pkg/providers/dns/testdata/end_to_end/create_zone_recordname_and_segmentconfig/modules/example_com/example_com.tf
+++ b/pkg/providers/dns/testdata/end_to_end/create_zone_recordname_and_segmentconfig/modules/example_com/example_com.tf
@@ -30,6 +30,7 @@ resource "akamai_dns_zone" "example_com" {
   comment                  = ""
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
+  multi_provider_dnssec = false
   target                   = ""
   end_customer_id          = ""
 }

--- a/pkg/providers/dns/testdata/end_to_end/create_zone_recordname_and_segmentconfig/modules/example_com/example_com.tf
+++ b/pkg/providers/dns/testdata/end_to_end/create_zone_recordname_and_segmentconfig/modules/example_com/example_com.tf
@@ -30,7 +30,7 @@ resource "akamai_dns_zone" "example_com" {
   comment                  = ""
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
-  multi_provider_dnssec = false
+  multi_provider_dnssec    = false
   target                   = ""
   end_customer_id          = ""
 }

--- a/pkg/providers/dns/testdata/end_to_end/create_zone_resources_and_config/example_com.tf
+++ b/pkg/providers/dns/testdata/end_to_end/create_zone_resources_and_config/example_com.tf
@@ -26,6 +26,7 @@ resource "akamai_dns_zone" "example_com" {
   comment                  = ""
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
+  multi_provider_dnssec = false
   target                   = ""
   end_customer_id          = ""
 }

--- a/pkg/providers/dns/testdata/end_to_end/create_zone_resources_and_config/example_com.tf
+++ b/pkg/providers/dns/testdata/end_to_end/create_zone_resources_and_config/example_com.tf
@@ -26,7 +26,7 @@ resource "akamai_dns_zone" "example_com" {
   comment                  = ""
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
-  multi_provider_dnssec = false
+  multi_provider_dnssec    = false
   target                   = ""
   end_customer_id          = ""
 }

--- a/pkg/providers/dns/testdata/end_to_end/create_zone_resources_config_and_importscript/example_com.tf
+++ b/pkg/providers/dns/testdata/end_to_end/create_zone_resources_config_and_importscript/example_com.tf
@@ -26,6 +26,7 @@ resource "akamai_dns_zone" "example_com" {
   comment                  = ""
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
+  multi_provider_dnssec = false
   target                   = ""
   end_customer_id          = ""
 }

--- a/pkg/providers/dns/testdata/end_to_end/create_zone_resources_config_and_importscript/example_com.tf
+++ b/pkg/providers/dns/testdata/end_to_end/create_zone_resources_config_and_importscript/example_com.tf
@@ -26,7 +26,7 @@ resource "akamai_dns_zone" "example_com" {
   comment                  = ""
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
-  multi_provider_dnssec = false
+  multi_provider_dnssec    = false
   target                   = ""
   end_customer_id          = ""
 }

--- a/pkg/providers/dns/testdata/end_to_end/create_zone_segmentconfig/modules/example_com/example_com.tf
+++ b/pkg/providers/dns/testdata/end_to_end/create_zone_segmentconfig/modules/example_com/example_com.tf
@@ -30,6 +30,7 @@ resource "akamai_dns_zone" "example_com" {
   comment                  = ""
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
+  multi_provider_dnssec = false
   target                   = ""
   end_customer_id          = ""
 }

--- a/pkg/providers/dns/testdata/end_to_end/create_zone_segmentconfig/modules/example_com/example_com.tf
+++ b/pkg/providers/dns/testdata/end_to_end/create_zone_segmentconfig/modules/example_com/example_com.tf
@@ -30,7 +30,7 @@ resource "akamai_dns_zone" "example_com" {
   comment                  = ""
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
-  multi_provider_dnssec = false
+  multi_provider_dnssec    = false
   target                   = ""
   end_customer_id          = ""
 }

--- a/pkg/providers/dns/testdata/end_to_end/create_zone_single_recordname/example_com.tf
+++ b/pkg/providers/dns/testdata/end_to_end/create_zone_single_recordname/example_com.tf
@@ -26,6 +26,7 @@ resource "akamai_dns_zone" "example_com" {
   comment                  = ""
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
+  multi_provider_dnssec = false
   target                   = ""
   end_customer_id          = ""
 }

--- a/pkg/providers/dns/testdata/end_to_end/create_zone_single_recordname/example_com.tf
+++ b/pkg/providers/dns/testdata/end_to_end/create_zone_single_recordname/example_com.tf
@@ -26,7 +26,7 @@ resource "akamai_dns_zone" "example_com" {
   comment                  = ""
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
-  multi_provider_dnssec = false
+  multi_provider_dnssec    = false
   target                   = ""
   end_customer_id          = ""
 }

--- a/pkg/providers/dns/testdata/zone/expected_zone.tf
+++ b/pkg/providers/dns/testdata/zone/expected_zone.tf
@@ -23,6 +23,7 @@ resource "akamai_dns_zone" "_0007770b-08a8-4b5f-a46b-081b772ba605-test_com" {
   comment                  = ""
   end_customer_id          = ""
   masters                  = []
+  multi_provider_dnssec    = false
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
   target                   = ""

--- a/pkg/providers/dns/testdata/zone/expected_zone_multi_provider_dnssec.tf
+++ b/pkg/providers/dns/testdata/zone/expected_zone_multi_provider_dnssec.tf
@@ -20,28 +20,15 @@ locals {
 resource "akamai_dns_zone" "_0007770b-08a8-4b5f-a46b-081b772ba605-test_com" {
   contract                 = var.contractid
   group                    = var.groupid
-  comment                  = <<EOT
-first
-second
-EOT
+  comment                  = ""
   end_customer_id          = ""
-  masters                  = ["1.1.1.1"]
-  multi_provider_dnssec    = false
-  sign_and_serve           = false
+  masters                  = []
+  multi_provider_dnssec    = true
+  sign_and_serve           = true
   sign_and_serve_algorithm = ""
-  outbound_zone_transfer {
-    acl            = ["192.0.2.156/24"]
-    enabled        = true
-    notify_targets = ["192.0.2.192"]
-    tsig_key {
-      algorithm = "hmac-sha1"
-      name      = "other.com.akamai.com"
-      secret    = "fakeSecretajVka5cHPEJQIXfLyx5V3PSkFBROAzOn21JumDq6nIpoj6H8rfj5Uo+Ok55ZWQ0Wgrf302fDscHLw=="
-    }
-  }
-  target = ""
-  type   = "SECONDARY"
-  zone   = local.zone
+  target                   = ""
+  type                     = "PRIMARY"
+  zone                     = local.zone
   tsig_key {
     name      = "some-name"
     algorithm = "some-algorithm"

--- a/pkg/providers/dns/testdata/zone/expected_zone_multiline.tf
+++ b/pkg/providers/dns/testdata/zone/expected_zone_multiline.tf
@@ -29,6 +29,7 @@ EOT
   , "\n")
   end_customer_id          = ""
   masters                  = []
+  multi_provider_dnssec    = false
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
   target                   = ""

--- a/pkg/providers/dns/testdata/zone_mod/mod/expected_zone_mod_res.tf
+++ b/pkg/providers/dns/testdata/zone_mod/mod/expected_zone_mod_res.tf
@@ -27,6 +27,7 @@ resource "akamai_dns_zone" "_0007770b-08a8-4b5f-a46b-081b772ba605-test_com" {
   comment                  = ""
   end_customer_id          = ""
   masters                  = []
+  multi_provider_dnssec    = false
   sign_and_serve           = false
   sign_and_serve_algorithm = ""
   target                   = ""

--- a/pkg/providers/dns/tf_zone.go
+++ b/pkg/providers/dns/tf_zone.go
@@ -8,6 +8,10 @@ import (
 
 // process zone
 func processZone(ctx context.Context, zone *dns.GetZoneResponse, resourceZoneName string, modSegment bool, fileUtils fileUtils, tfWorkPath string) (string, error) {
+	multiProviderDNSSEC := false
+	if zone.MultiProviderDNSSEC != nil {
+		multiProviderDNSSEC = zone.MultiProviderDNSSEC.Enabled
+	}
 	data := ZoneData{
 		BlockName:             resourceZoneName,
 		Zone:                  zone.Zone,
@@ -16,6 +20,7 @@ func processZone(ctx context.Context, zone *dns.GetZoneResponse, resourceZoneNam
 		Comment:               zone.Comment,
 		SignAndServe:          zone.SignAndServe,
 		SignAndServeAlgorithm: zone.SignAndServeAlgorithm,
+		MultiProviderDNSSEC:   multiProviderDNSSEC,
 		OutboundZoneTransfer:  zone.OutboundZoneTransfer,
 		TSIGKey:               zone.TSIGKey,
 		Target:                zone.Target,

--- a/pkg/providers/dns/tf_zone_test.go
+++ b/pkg/providers/dns/tf_zone_test.go
@@ -82,6 +82,25 @@ func TestProcessZone(t *testing.T) {
 				TSIGKey: &dns.TSIGKey{Name: "some-name", Algorithm: "some-algorithm", Secret: "some-secret"},
 			},
 		},
+		"modSegment=false, multi-signer DNSSEC enabled": {
+			filePath:   "./testdata/zone/expected_zone_multi_provider_dnssec.tf",
+			modSegment: false,
+			zoneResponse: dns.GetZoneResponse{
+				Zone:               "0007770b-08a8-4b5f-a46b-081b772ba605-test.com",
+				Type:               "PRIMARY",
+				Masters:            []string{},
+				ContractID:         "test_contract",
+				ActivationState:    "NEW",
+				LastModifiedBy:     "jreed",
+				LastActivationDate: "2021-03-16T17:16:59.208264Z",
+				VersionID:          "fd858f59-6014-4ce4-8372-c08389d809e8",
+				SignAndServe:       true,
+				MultiProviderDNSSEC: &dns.MultiProviderDNSSEC{
+					Enabled: true,
+				},
+				TSIGKey: &dns.TSIGKey{Name: "some-name", Algorithm: "some-algorithm", Secret: "some-secret"},
+			},
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
feat: export multi_provider_dnssec in akamai_dns_zone
Per @mimazaka's review comment on terraform-provider-akamai PR #774,
cli-terraform's export-zone command needs to know about the
multi_provider_dnssec field (added to the akamai_dns_zone resource in
that PR) — otherwise exporting a zone with multi-signer DNSSEC enabled
would produce a .tf file missing the attribute, causing a Terraform
plan diff immediately after import.